### PR TITLE
apply new build script

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 
+REPO=github.com/rebuy-de/kubernetes-deployment
+ROOT=$(readlink -f $( dirname $0)/..)
+COMMAND=${1:-all}
+
 set -ex
 
-cd $( dirname $0 )/..
-
-mkdir -p target
-
-VERSION=$(git describe --always --dirty | tr '-' '.' )
-
-go test -v ./...
-
-go build \
-	-o target/kubernetes-deployment \
-	-ldflags "-X main.version=${VERSION}" 
+docker run \
+	--rm \
+	-v "${ROOT}:/go/src/${REPO}" \
+	074509403805.dkr.ecr.eu-west-1.amazonaws.com/rebuy-base-image-golang:latest \
+    /tools/build.sh ${COMMAND} ${REPO}


### PR DESCRIPTION
Uses new build tools from the golang base image:

It haz:
- cross compiling (atm for `amd64-linux` and `amd64-darwin`, see [here](http://jenkins.rebuy.loc/job/kubernetes-deployment-golang-github/ws/src/github.com/rebuy-de/kubernetes-deployment/target/))
- code coverage, see [here](http://jenkins.rebuy.loc/job/kubernetes-deployment-golang-github/ws/src/github.com/rebuy-de/kubernetes-deployment/target/coverage.html) (no idea why Jenkins fucks up the formatting)
