### PR TITLE
fix config

### DIFF
--- a/app.go
+++ b/app.go
@@ -11,28 +11,28 @@ import (
 
 	"github.com/rebuy-de/kubernetes-deployment/git"
 	"github.com/rebuy-de/kubernetes-deployment/kubernetes"
-	"github.com/rebuy-de/kubernetes-deployment/templates"
 	"github.com/rebuy-de/kubernetes-deployment/settings"
+	"github.com/rebuy-de/kubernetes-deployment/templates"
 )
 
 type App struct {
-	KubectlBuilder       func(kubeconfig *string) (kubernetes.API, error)
-	Kubectl              kubernetes.API
-	ProjectConfigPath    string
-	LocalConfigPath      string
-	OutputPath           string
+	KubectlBuilder    func(kubeconfig *string) (kubernetes.API, error)
+	Kubectl           kubernetes.API
+	ProjectConfigPath string
+	LocalConfigPath   string
+	OutputPath        string
 
 	SleepInterval        time.Duration
 	IgnoreDeployFailures bool
 
-	RetrySleep           time.Duration
-	RetryCount           int
+	RetrySleep time.Duration
+	RetryCount int
 
-	SkipShuffle          bool
-	SkipFetch            bool
-	SkipDeploy           bool
+	SkipShuffle bool
+	SkipFetch   bool
+	SkipDeploy  bool
 
-	Errors               []error
+	Errors []error
 }
 
 const templatesSubfolder = "templates"
@@ -282,6 +282,9 @@ func (app *App) DeployService(service *settings.Service) error {
 }
 
 func (app *App) DisplayErrors() {
+	if len(app.Errors) == 0 {
+		return
+	}
 
 	fmt.Fprintf(os.Stderr, "\nError(s) occured:\n")
 	for i, err := range app.Errors {

--- a/app_test.go
+++ b/app_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/rebuy-de/kubernetes-deployment/git"
 	"github.com/rebuy-de/kubernetes-deployment/kubernetes"
-	"github.com/rebuy-de/kubernetes-deployment/util"
 	"github.com/rebuy-de/kubernetes-deployment/settings"
+	"github.com/rebuy-de/kubernetes-deployment/util"
 )
 
 type testKubectl struct {
@@ -78,12 +78,12 @@ func prepareTestEnvironment(t *testing.T) (*App, *testKubectl, func()) {
 
 	cleanup = createTestGitRepo(t,
 		path.Join(tempDir, "repos", "bish"),
-		"master", "/deployment/kubernetes",
+		"master", "/deployment/k8s",
 		"bish-a.yml", "bish-b.yml", "bish-c.yaml", "bish-d.txt", "foo/bish-e.yml")
 
 	cleanup = createTestGitRepo(t,
 		path.Join(tempDir, "repos", "bash"),
-		"special", "/deployment/kubernetes",
+		"special", "/deployment/k8s",
 		"bash-a.yml", "bash-b.yml", "bash-c.yaml", "bash-d.txt", "foo/bash-e.yml")
 
 	cleanup = createTestGitRepo(t,

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -25,14 +25,9 @@ services:
   - repo: github.com/rebuy-de/cloud-infrastructure
     path: /kube-dashboard
   - repo: github.com/rebuy-de/solr-management-silo
-    path: /kubernetes/manifests
     branch: cloud-350
   - repo: github.com/rebuy-de/green-web
-    path: /deployment/k8s
     branch: dockerize
   - repo: github.com/rebuy-de/blue-web
-    path: /deployment/k8s
-    branch: k8s-build
   - repo: github.com/rebuy-de/my-web
-    path: /deployment/k8s
     branch: CLOUD-424-dockerize

--- a/git/git.go
+++ b/git/git.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path"
 	"strings"
+
 	"github.com/rebuy-de/kubernetes-deployment/util"
 )
 
@@ -74,5 +75,6 @@ func (g *Git) PullShallow(branch string) error {
 
 func (g *Git) SetCheckoutPath(dir string) error {
 	infoFile := path.Join(g.Directory, ".git", "info", "sparse-checkout")
+	log.Printf("Writing '%s' to %s", dir, infoFile)
 	return ioutil.WriteFile(infoFile, []byte(dir), 0644)
 }

--- a/settings/service.go
+++ b/settings/service.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	DEFAULT_BRANCH = "master"
-	DEFAULT_PATH   = "/deployment/kubernetes"
+	DEFAULT_PATH   = "/deployment/k8s"
 )
 
 type Service struct {

--- a/settings/service_test.go
+++ b/settings/service_test.go
@@ -14,7 +14,7 @@ func TestClean(t *testing.T) {
 			Service{
 				Name:       "something",
 				Repository: "git@github.com:rebuy-de/something.git",
-				Path:       "/deployment/kubernetes",
+				Path:       "/deployment/k8s",
 				Branch:     "master",
 			},
 		},
@@ -25,7 +25,7 @@ func TestClean(t *testing.T) {
 			Service{
 				Name:       "http:--veryspecial.com-repos-foo",
 				Repository: "http://veryspecial.com/repos/foo",
-				Path:       "/deployment/kubernetes",
+				Path:       "/deployment/k8s",
 				Branch:     "master",
 			},
 		},
@@ -37,7 +37,7 @@ func TestClean(t *testing.T) {
 			Service{
 				Name:       "blubber-special",
 				Repository: "git@github.com:rebuy-de/blubber.git",
-				Path:       "/deployment/kubernetes",
+				Path:       "/deployment/k8s",
 				Branch:     "special",
 			},
 		},


### PR DESCRIPTION
* somebody doesn't use gofmt style
* updated `config/services.yaml` to our current repo structure
* set default path to `/deployment/k8s` to match our real default

@rebuy-de/prp-kubernetes-deployment Please review.