### PR TITLE
Add commands

### DIFF
--- a/app_test.go
+++ b/app_test.go
@@ -112,6 +112,11 @@ func prepareTestEnvironment(t *testing.T) (*App, *testKubectl, func()) {
 
 	kubectlMock := new(testKubectl)
 
+	commands, err := GetCommands("all")
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	return &App{
 		KubectlBuilder: func(*string) (kubernetes.API, error) {
 			return kubectlMock, nil
@@ -126,21 +131,24 @@ func prepareTestEnvironment(t *testing.T) (*App, *testKubectl, func()) {
 		RetryCount: 3,
 
 		SkipShuffle: false,
-		SkipFetch:   false,
-		SkipDeploy:  false,
+		Commands:    commands,
 	}, kubectlMock, cleanup
 }
 
 func TestSkipAll(t *testing.T) {
+	var err error
+
 	app, _, cleanup := prepareTestEnvironment(t)
 	defer cleanup()
 
 	app.SkipShuffle = true
-	app.SkipFetch = true
-	app.SkipDeploy = true
 	app.IgnoreDeployFailures = false
+	app.Commands, err = GetCommands("all")
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	err := app.Run()
+	err = app.Run()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/command-deploy.go
+++ b/command-deploy.go
@@ -5,11 +5,12 @@ import (
 	"path"
 	"time"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/rebuy-de/kubernetes-deployment/settings"
 )
 
-func (app *App) DeployServices(config *settings.ProjectConfig) error {
-	for i, service := range *config.Services {
+func DeployServicesCommand(app *App) error {
+	for i, service := range *app.Config.Services {
 		if i != 0 && app.SleepInterval > 0 {
 			log.Infof("Sleeping %v ...", app.SleepInterval)
 			time.Sleep(app.SleepInterval)

--- a/command-deploy.go
+++ b/command-deploy.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"fmt"
+	"path"
+	"time"
+
+	"github.com/rebuy-de/kubernetes-deployment/settings"
+)
+
+func (app *App) DeployServices(config *settings.ProjectConfig) error {
+	for i, service := range *config.Services {
+		if i != 0 && app.SleepInterval > 0 {
+			log.Infof("Sleeping %v ...", app.SleepInterval)
+			time.Sleep(app.SleepInterval)
+		}
+
+		if app.SkipDeploy {
+			log.Warn("Skip deploying manifests to Kubernetes.")
+		} else {
+			err := app.DeployService(service)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (app *App) DeployService(service *settings.Service) error {
+	manifestPath := path.Join(app.OutputPath, renderedSubfolder, service.Name)
+	manifests, err := FindFiles(manifestPath, "*.yml", "*.yaml")
+	if err != nil {
+		return err
+	}
+
+	if len(manifests) == 0 {
+		return fmt.Errorf("Did not find any manifest for '%s' in '%s'",
+			service.Name, manifestPath)
+	}
+
+	for _, manifestInputFile := range manifests {
+		if err != nil {
+			return err
+		}
+
+		log.Infof("Applying manifest '%s'", manifestInputFile)
+		err := app.Retry(func() error {
+			_, err := app.Kubectl.Apply(manifestInputFile)
+			return err
+		})
+		if err != nil && app.IgnoreDeployFailures {
+			log.Errorf("Ignoring failed deployment of %s", service.Name)
+			app.Errors = append(app.Errors,
+				fmt.Errorf("Deployment of '%s' in service '%s' failed: %v",
+					manifestInputFile, service.Name, err),
+			)
+		}
+		if err != nil && !app.IgnoreDeployFailures {
+			return err
+		}
+	}
+	return nil
+}

--- a/command-fetch.go
+++ b/command-fetch.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/rebuy-de/kubernetes-deployment/git"
+	"github.com/rebuy-de/kubernetes-deployment/settings"
+)
+
+func (app *App) FetchServices(config *settings.ProjectConfig) error {
+	if app.SkipFetch {
+		log.Warn("Skip fetching manifests via git.")
+		return nil
+	}
+
+	for _, service := range *config.Services {
+		err := app.Retry(func() error {
+			return app.FetchService(service, config)
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (app *App) FetchService(service *settings.Service, config *settings.ProjectConfig) error {
+	tempDir, err := ioutil.TempDir("", "kubernetes-deployment-checkout-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tempDir)
+
+	err = git.SparseCheckout(tempDir, service.Repository, service.Branch, service.Path)
+	if err != nil {
+		return err
+	}
+
+	manifests, err := FindFiles(path.Join(tempDir, service.Path), "*.yml", "*.yaml")
+	if err != nil {
+		return err
+	}
+
+	outputPath := path.Join(app.OutputPath, templatesSubfolder, service.Name)
+	err = os.MkdirAll(outputPath, 0755)
+	if err != nil {
+		return err
+	}
+
+	for _, manifest := range manifests {
+		name := path.Base(manifest)
+		target := path.Join(outputPath, name)
+		log.Infof("Copying manifest to '%s'", target)
+
+		err := CopyFile(manifest, target)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/command-fetch.go
+++ b/command-fetch.go
@@ -5,19 +5,20 @@ import (
 	"os"
 	"path"
 
+	log "github.com/Sirupsen/logrus"
 	"github.com/rebuy-de/kubernetes-deployment/git"
 	"github.com/rebuy-de/kubernetes-deployment/settings"
 )
 
-func (app *App) FetchServices(config *settings.ProjectConfig) error {
+func FetchServicesCommand(app *App) error {
 	if app.SkipFetch {
 		log.Warn("Skip fetching manifests via git.")
 		return nil
 	}
 
-	for _, service := range *config.Services {
+	for _, service := range *app.Config.Services {
 		err := app.Retry(func() error {
-			return app.FetchService(service, config)
+			return app.FetchService(service, app.Config)
 		})
 		if err != nil {
 			return err

--- a/command-render.go
+++ b/command-render.go
@@ -5,14 +5,14 @@ import (
 	"path"
 	"path/filepath"
 
-	"github.com/cloudflare/cfssl/log"
+	log "github.com/Sirupsen/logrus"
 	"github.com/rebuy-de/kubernetes-deployment/settings"
 	"github.com/rebuy-de/kubernetes-deployment/templates"
 )
 
-func (app *App) RenderTemplates(config *settings.ProjectConfig) error {
+func RenderTemplatesCommand(app *App) error {
 
-	for _, service := range *config.Services {
+	for _, service := range *app.Config.Services {
 		manifestInputPath := path.Join(app.OutputPath, templatesSubfolder, service.Name)
 		manifestPath := path.Join(app.OutputPath, renderedSubfolder, service.Name)
 		log.Debugf("Create folder '%s'", manifestPath)
@@ -25,7 +25,7 @@ func (app *App) RenderTemplates(config *settings.ProjectConfig) error {
 		manifests, err := FindFiles(manifestInputPath, "*.yml", "*.yaml")
 
 		for _, manifestInputFile := range manifests {
-			err = app.renderTemplate(manifestInputFile, manifestPath, config)
+			err = app.renderTemplate(manifestInputFile, manifestPath, app.Config)
 			if err != nil {
 				return err
 			}

--- a/command-render.go
+++ b/command-render.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+
+	"github.com/cloudflare/cfssl/log"
+	"github.com/rebuy-de/kubernetes-deployment/settings"
+	"github.com/rebuy-de/kubernetes-deployment/templates"
+)
+
+func (app *App) RenderTemplates(config *settings.ProjectConfig) error {
+
+	for _, service := range *config.Services {
+		manifestInputPath := path.Join(app.OutputPath, templatesSubfolder, service.Name)
+		manifestPath := path.Join(app.OutputPath, renderedSubfolder, service.Name)
+		log.Debugf("Create folder '%s'", manifestPath)
+
+		err := os.MkdirAll(manifestPath, 0755)
+		if err != nil {
+			return err
+		}
+
+		manifests, err := FindFiles(manifestInputPath, "*.yml", "*.yaml")
+
+		for _, manifestInputFile := range manifests {
+			err = app.renderTemplate(manifestInputFile, manifestPath, config)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (app *App) renderTemplate(manifestInputFile string, manifestPath string, config *settings.ProjectConfig) error {
+	_, manifestFileName := filepath.Split(manifestInputFile)
+
+	manifestOutputFile := path.Join(manifestPath, manifestFileName)
+	log.Infof("Templating '%s' to '%s'", manifestInputFile, manifestOutputFile)
+	err := templates.ParseManifestFile(manifestInputFile, manifestOutputFile, config.Settings.TemplateValuesMap)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/commands.go
+++ b/commands.go
@@ -1,3 +1,54 @@
 package main
 
+import "fmt"
+
 type Command func(app *App) error
+
+var (
+	CommandMapping = map[string]Command{
+		"fetch":  FetchServicesCommand,
+		"render": RenderTemplatesCommand,
+		"deploy": DeployServicesCommand,
+	}
+	CommandAliases = map[string][]string{
+		"all": []string{"fetch", "render", "deploy"},
+	}
+	CommandOrder = []string{
+		"fetch", "render", "deploy",
+	}
+)
+
+func GetCommands(names ...string) ([]Command, error) {
+	unaliased := []string{}
+	for _, name := range names {
+		replace, ok := CommandAliases[name]
+		if ok {
+			unaliased = append(unaliased, replace...)
+		} else {
+			unaliased = append(unaliased, name)
+		}
+	}
+
+	commands := make(map[string]bool)
+	for _, name := range CommandOrder {
+		commands[name] = false
+	}
+
+	for _, name := range unaliased {
+		_, ok := CommandMapping[name]
+		if !ok {
+			return nil, fmt.Errorf("Unknown command %s", name)
+		}
+
+		commands[name] = true
+	}
+
+	result := []Command{}
+	for _, name := range CommandOrder {
+		if commands[name] {
+			result = append(result, CommandMapping[name])
+		}
+	}
+
+	return result, nil
+}

--- a/commands.go
+++ b/commands.go
@@ -1,0 +1,3 @@
+package main
+
+type Command func(app *App) error

--- a/commands_test.go
+++ b/commands_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"reflect"
+	"runtime"
+	"testing"
+)
+
+func testGetNameOfFn(fn interface{}) string {
+	return runtime.FuncForPC(reflect.ValueOf(fn).Pointer()).Name()
+}
+
+func TestGetCommands(t *testing.T) {
+	var cases = []struct {
+		names  []string
+		expect []string
+	}{
+		{
+			[]string{"all"},
+			[]string{
+				testGetNameOfFn(FetchServicesCommand),
+				testGetNameOfFn(RenderTemplatesCommand),
+				testGetNameOfFn(DeployServicesCommand),
+			},
+		},
+		{
+			[]string{"fetch", "render", "deploy"},
+			[]string{
+				testGetNameOfFn(FetchServicesCommand),
+				testGetNameOfFn(RenderTemplatesCommand),
+				testGetNameOfFn(DeployServicesCommand),
+			},
+		},
+		{
+			[]string{"all", "fetch", "render", "deploy"},
+			[]string{
+				testGetNameOfFn(FetchServicesCommand),
+				testGetNameOfFn(RenderTemplatesCommand),
+				testGetNameOfFn(DeployServicesCommand),
+			},
+		},
+		{
+			[]string{"deploy", "render", "deploy", "fetch"},
+			[]string{
+				testGetNameOfFn(FetchServicesCommand),
+				testGetNameOfFn(RenderTemplatesCommand),
+				testGetNameOfFn(DeployServicesCommand),
+			},
+		},
+		{
+			[]string{"fetch"},
+			[]string{
+				testGetNameOfFn(FetchServicesCommand),
+			},
+		},
+	}
+
+	for i, tc := range cases {
+		commands, err := GetCommands(tc.names...)
+		if err != nil {
+			t.Errorf("Test case %d failed.", i)
+			t.Errorf("  in:    %v", tc.names)
+			t.Errorf("  error: %v", err)
+		}
+
+		commandNames := make([]string, len(commands))
+		for i, command := range commands {
+			commandNames[i] = testGetNameOfFn(command)
+		}
+
+		if !reflect.DeepEqual(commandNames, tc.expect) {
+			t.Errorf("Test case %d failed.", i)
+			t.Errorf("  in:       %v", tc.names)
+			t.Errorf("  out:      %v", commandNames)
+			t.Errorf("  expected: %v", tc.expect)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -44,14 +44,6 @@ func Main(args ...string) int {
 		&app.SkipShuffle,
 		"skip-shuffle", false,
 		"skip shuffling of project order")
-	fs.BoolVar(
-		&app.SkipFetch,
-		"skip-fetch", false,
-		"skip fetching files via git; requires valid files in the output directory")
-	fs.BoolVar(
-		&app.SkipDeploy,
-		"skip-deploy", false,
-		"skip applying the manifests to kubectl")
 
 	err := fs.Parse(args)
 	if err != nil {
@@ -61,6 +53,17 @@ func Main(args ...string) int {
 	if printVersion {
 		fmt.Printf("kubernetes-deployment version %s\n", version)
 		return 0
+	}
+
+	app.Commands, err = GetCommands(fs.Args()...)
+	if err != nil {
+		fmt.Println(err)
+		return 2
+	}
+
+	if len(app.Commands) == 0 {
+		fmt.Printf("You have to specify at least one of these commands: %v\n", CommandOrder)
+		return 2
 	}
 
 	app.KubectlBuilder = func(kubeconfig *string) (kubernetes.API, error) {

--- a/settings/setting.go
+++ b/settings/setting.go
@@ -7,8 +7,6 @@ type Settings struct {
 	Output               *string          `yaml:"output"`
 	Sleep                *time.Duration   `yaml:"sleep"`
 	SkipShuffle          *bool            `yaml:"skip-shuffle"`
-	SkipFetch            *bool            `yaml:"skip-fetch"`
-	SkipDeploy           *bool            `yaml:"skip-deploy"`
 	RetrySleep           *time.Duration   `yaml:"retry-sleep"`
 	RetryCount           *int             `yaml:"retry-count"`
 	IgnoreDeployFailures *bool            `yaml:"ignore-deploy-failures"`


### PR DESCRIPTION
Use commands instead of `-skip-*` flags.

Now we can do:

* `kubernetes-deployment fetch`
* `kubernetes-deployment render`
* `kubernetes-deployment deploy`
* `kubernetes-deployment all`

Also I splitted the commands into different files, so the PR looks bigger than it actually is.