### PR TITLE
fix commands

### DIFF
--- a/app.go
+++ b/app.go
@@ -124,12 +124,6 @@ func (app *App) PrepareConfig() error {
 
 	log.Printf("Deploying with this project configuration:\n%s", config)
 
-	log.Warnf("Wiping output directory '%s'!", *config.Settings.Output)
-	err = os.RemoveAll(*config.Settings.Output)
-	if err != nil {
-		return err
-	}
-
 	err = os.MkdirAll(*config.Settings.Output, 0755)
 	if err != nil {
 		return err
@@ -155,4 +149,16 @@ func (app *App) DisplayErrors() {
 	for i, err := range app.Errors {
 		fmt.Fprintf(os.Stderr, "    #%2d: %v\n", i, err)
 	}
+}
+
+func (app *App) wipeDirectory(dir string) error {
+	targetDirectory := path.Join(app.OutputPath, dir)
+	log.Infof("Wiping directory %s", targetDirectory)
+
+	err := os.RemoveAll(targetDirectory)
+	if err != nil {
+		return err
+	}
+
+	return os.MkdirAll(targetDirectory, 0755)
 }

--- a/command-fetch.go
+++ b/command-fetch.go
@@ -11,9 +11,21 @@ import (
 )
 
 func FetchServicesCommand(app *App) error {
+	var err error
+
 	if app.SkipFetch {
 		log.Warn("Skip fetching manifests via git.")
 		return nil
+	}
+
+	err = app.wipeDirectory(templatesSubfolder)
+	if err != nil {
+		return err
+	}
+
+	err = app.wipeDirectory(renderedSubfolder)
+	if err != nil {
+		return err
 	}
 
 	for _, service := range *app.Config.Services {
@@ -31,6 +43,8 @@ func FetchServicesCommand(app *App) error {
 }
 
 func (app *App) FetchService(service *settings.Service, config *settings.ProjectConfig) error {
+	var err error
+
 	tempDir, err := ioutil.TempDir("", "kubernetes-deployment-checkout-")
 	if err != nil {
 		return err

--- a/command-render.go
+++ b/command-render.go
@@ -11,6 +11,12 @@ import (
 )
 
 func RenderTemplatesCommand(app *App) error {
+	var err error
+
+	err = app.wipeDirectory(renderedSubfolder)
+	if err != nil {
+		return err
+	}
 
 	for _, service := range *app.Config.Services {
 		manifestInputPath := path.Join(app.OutputPath, templatesSubfolder, service.Name)


### PR DESCRIPTION
This makes kubernetes-deployment not remove the output directory on each start, so we are able to use other commands than `all`.

@rebuy-de/prp-kubernetes-deployment Please review.