### PR TITLE
don't overwrite service name

### DIFF
--- a/settings/service.go
+++ b/settings/service.go
@@ -34,7 +34,9 @@ func (s *Service) Clean() {
 	}
 
 	s.Path = filepath.Clean(strings.Trim(s.Path, "/")) + "/"
-	s.Name = s.GuessName()
+	if strings.TrimSpace(s.Name) == "" {
+		s.Name = s.GuessName()
+	}
 }
 
 func (s *Service) GuessName() string {

--- a/settings/service_test.go
+++ b/settings/service_test.go
@@ -57,6 +57,20 @@ func TestClean(t *testing.T) {
 				Branch:     "some-branch",
 			},
 		},
+		{
+			Service{
+				Name:       "project",
+				Repository: "github.com/rebuy-de/project",
+				Branch:     "some-branch",
+				Path:       "/i/dont/care/about/conventions",
+			},
+			Service{
+				Name:       "project",
+				Repository: "git@github.com:rebuy-de/project.git",
+				Path:       "i/dont/care/about/conventions/",
+				Branch:     "some-branch",
+			},
+		},
 	}
 
 	for i, tt := range cleantests {


### PR DESCRIPTION
Fix to not overwrite service name. That means with 

```yaml
services:
  - name: rabbitmq
    repo: github.com/rebuy-de/k8s-rabbitmq
    path: manifests
```

I want to do `kubernetes-deployment -t rabbitmq all` and not `kubernetes-deployment -t k8s-rabbitmq-manifests all`.