### PR TITLE
Fix key case

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 /vendor
 /config/services-out.yaml
 /output
-/kubernetes-deployment
+/kubernetes-deployment*
 /cmd/target

--- a/cmd/goal_fetch.go
+++ b/cmd/goal_fetch.go
@@ -62,8 +62,7 @@ func (app *App) FetchService(service *settings.Service) error {
 
 	log.Infof("Checked out %s", commitID)
 	mergo.Merge(&service.TemplateValues, map[string]string{
-		"gitCommitID":   commitID,
-		"git-commit-id": commitID,
+		"gitCommitID": commitID,
 	})
 
 	manifests, err := FindFiles(path.Join(tempDir, service.Path), "*.yml", "*.yaml")

--- a/cmd/goal_render.go
+++ b/cmd/goal_render.go
@@ -33,12 +33,14 @@ func RenderTemplatesGoal(app *App) error {
 		log.Debug("Config file template values: %#v", app.Config.Settings.TemplateValues)
 		log.Debug("Project template values: %#v", service.TemplateValues)
 
-		mergo.Merge(&service.TemplateValues, app.Config.Settings.TemplateValues)
+		values := service.TemplateValues.ToMap()
 
-		log.Debug("Merged template values: %#v", service.TemplateValues)
+		mergo.Merge(&values, app.Config.Settings.TemplateValues.ToMap())
+
+		log.Debug("Merged template values: %#v", values)
 
 		for _, manifestInputFile := range manifests {
-			err = app.renderTemplate(manifestInputFile, manifestPath, service.TemplateValues)
+			err = app.renderTemplate(manifestInputFile, manifestPath, values)
 			if err != nil {
 				return err
 			}

--- a/cmd/test-fixtures/services_test.yaml
+++ b/cmd/test-fixtures/services_test.yaml
@@ -5,7 +5,8 @@ settings:
   retry-sleep: 250ms
   retry-count: 3
   template-values:
-    clusterDomain: unit-test.example.org
+  - name: clusterDomain
+    value: unit-test.example.org
 services:
   - name: bish
     repo: repos/bish

--- a/pkg/settings/builder.go
+++ b/pkg/settings/builder.go
@@ -44,6 +44,7 @@ func NewBuilder(fs *pflag.FlagSet) SettingsBuilder {
 
 		s := ProjectConfig{}
 		v.Unmarshal(&s)
+
 		return s
 	}
 }

--- a/pkg/settings/builder_test.go
+++ b/pkg/settings/builder_test.go
@@ -37,8 +37,11 @@ func TestBuilder(t *testing.T) {
 			RetrySleep:           250000000,
 			RetryCount:           3,
 			IgnoreDeployFailures: false,
-			TemplateValues: map[string]string{
-				"cluster-domain": "unit-test.example.org",
+			TemplateValues: TemplateValues{
+				TemplateValue{
+					Name:  "clusterDomain",
+					Value: "unit-test.example.org",
+				},
 			},
 		},
 	}

--- a/pkg/settings/service.go
+++ b/pkg/settings/service.go
@@ -12,11 +12,11 @@ const (
 )
 
 type Service struct {
-	Name           string            `yaml:"name,omitempty"`
-	Repository     string            `yaml:"repo" mapstructure:"repo"`
-	Path           string            `yaml:"path,omitempty"`
-	Branch         string            `yaml:"branch,omitempty"`
-	TemplateValues map[string]string `yaml:"template-values"`
+	Name           string         `yaml:"name,omitempty"`
+	Repository     string         `yaml:"repo" mapstructure:"repo"`
+	Path           string         `yaml:"path,omitempty"`
+	Branch         string         `yaml:"branch,omitempty"`
+	TemplateValues TemplateValues `yaml:"template-values"`
 }
 
 func (s *Service) Clean() {

--- a/pkg/settings/setting.go
+++ b/pkg/settings/setting.go
@@ -3,12 +3,29 @@ package settings
 import "time"
 
 type Settings struct {
-	Kubeconfig           string            `yaml:"kubeconfig"`
-	Output               string            `yaml:"output"`
-	Sleep                time.Duration     `yaml:"sleep"`
-	SkipShuffle          bool              `yaml:"skip-shuffle" mapstructure:"skip-shuffle"`
-	RetrySleep           time.Duration     `yaml:"retry-sleep" mapstructure:"retry-sleep"`
-	RetryCount           int               `yaml:"retry-count" mapstructure:"retry-count"`
-	IgnoreDeployFailures bool              `yaml:"ignore-deploy-failures" mapstructure:"ignore-deploy-failures"`
-	TemplateValues       map[string]string `yaml:"template-values" mapstructure:"template-values"`
+	Kubeconfig           string         `yaml:"kubeconfig"`
+	Output               string         `yaml:"output"`
+	Sleep                time.Duration  `yaml:"sleep"`
+	SkipShuffle          bool           `yaml:"skip-shuffle" mapstructure:"skip-shuffle"`
+	RetrySleep           time.Duration  `yaml:"retry-sleep" mapstructure:"retry-sleep"`
+	RetryCount           int            `yaml:"retry-count" mapstructure:"retry-count"`
+	IgnoreDeployFailures bool           `yaml:"ignore-deploy-failures" mapstructure:"ignore-deploy-failures"`
+	TemplateValues       TemplateValues `yaml:"template-values" mapstructure:"template-values"`
+}
+
+type TemplateValues []TemplateValue
+
+func (tv TemplateValues) ToMap() map[string]string {
+	result := make(map[string]string)
+
+	for _, kv := range tv {
+		result[kv.Name] = kv.Value
+	}
+
+	return result
+}
+
+type TemplateValue struct {
+	Name  string `yaml:"name" mapstructure:"name"`
+	Value string `yaml:"value" mapstructure:"value"`
 }

--- a/pkg/settings/test-fixtures/services_test.yaml
+++ b/pkg/settings/test-fixtures/services_test.yaml
@@ -5,7 +5,8 @@ settings:
   retry-sleep: 250ms
   retry-count: 3
   template-values:
-    cluster-domain: unit-test.example.org
+  - name: clusterDomain
+    value: unit-test.example.org
 services:
   - repo: repos/bish
   - repo: repos/bash


### PR DESCRIPTION
Fix case, because `cluster-domain` isn't allowed by Golang templates.