### PR TITLE
Use fetch instead of pull

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -105,7 +105,7 @@ func (g *Git) Config(key, value string) error {
 }
 
 func (g *Git) PullShallow(branch string) error {
-	err := g.Exec("pull", "--depth=1", "origin", "master")
+	err := g.Exec("fetch", "origin")
 
 	if err != nil {
 		return err


### PR DESCRIPTION
@rebuy-de/prp-kubernetes-deployment Use fetch, not pull, to allow test of newly created kubernetes manifests using branch deployment.

**Please review!**