### PR TITLE
fix template rendering

### DIFF
--- a/pkg/templates/render.go
+++ b/pkg/templates/render.go
@@ -2,8 +2,8 @@ package templates
 
 import (
 	"bytes"
-	"html/template"
 	"strings"
+	"text/template"
 
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
We need to use the `text` package instead of the `html` package to rendering templates. Otherwise it tries to escape the templates, which converts stuff like `<` into `&lt;`.

@rebuy-de/prp-kubernetes-deployment Please review.