### PR TITLE
add facility for Graylog labels

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,8 @@ func NewRootCommand() *cobra.Command {
 		if params.GELFAddress != "" {
 			hook := graylog.NewGraylogHook(params.GELFAddress,
 				map[string]interface{}{
-					"run": randomID(),
+					"run":      randomID(),
+					"facility": "kubernetes-deployment",
 				})
 			hook.Level = log.DebugLevel
 			log.AddHook(hook)


### PR DESCRIPTION
We want to filter messages by `facility` like in our other services.

@rebuy-de/prp-kubernetes-deployment Please review.