### PR TITLE
add identifier template function

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,19 @@ The key names in the configuration files always equals the long command line fla
 filename: github.com/rebuy-de/cloud-infrastructure/deployments.yaml
 github-token: aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d
 ```
+### Templates
 
-### Variables
+All Kubernetes manifests will be rendered with the [Golang template engine](https://golang.org/pkg/text/template/).
+
+#### Functions
+
+The following functions are provided:
+
+* `ToLower` - converts the string to lowercase chars
+* `ToUpper` - converts the string to uppercase chars
+` `Identifier` - converts the string to a valid Kubernetes identifier (eg for the `meta.name` field)
+
+#### Variables
 
 `kubernetes-deployment` uses variables which are inherited in a specific order. Each item overwrites the previous one:
 
@@ -45,3 +56,6 @@ These are the generated values:
 
 * `gitBranchName` - The branch name from GitHub, eg `master`.
 * `gitCommitID` - The full git commit hash, eg `afad13cf1941af4ad3101bdf30f087f7dfe27c99`. Useful for image tags.
+
+
+

--- a/pkg/templates/functions.go
+++ b/pkg/templates/functions.go
@@ -1,0 +1,17 @@
+package templates
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Matches all invalid chars from rfc1035/rfc1123.
+// See also: https://github.com/kubernetes/community/blob/master/contributors/design-proposals/identifiers.md
+var IdentifierInvalidRe = regexp.MustCompile("[^a-z0-9]+")
+
+func IdentifierFunc(s string) string {
+	s = strings.ToLower(s)
+	s = IdentifierInvalidRe.ReplaceAllLiteralString(s, "-")
+	s = strings.Trim(s, "-")
+	return s
+}

--- a/pkg/templates/functions_test.go
+++ b/pkg/templates/functions_test.go
@@ -1,0 +1,22 @@
+package templates
+
+import "testing"
+
+func TestIdentifierFunc(t *testing.T) {
+	tests := []struct {
+		in  string
+		out string
+	}{
+		{"-ab-:_.fSDf123axxb-", "ab-fsdf123axxb"},
+		{"------", ""},
+		{"angular-4.2.0", "angular-4-2-0"},
+		{"BLUE-1337__fancy-feature", "blue-1337-fancy-feature"},
+	}
+
+	for i, tc := range tests {
+		out := IdentifierFunc(tc.in)
+		if out != tc.out {
+			t.Errorf("Test Case %d failed: %#v != %#v", i, out, tc.out)
+		}
+	}
+}

--- a/pkg/templates/render.go
+++ b/pkg/templates/render.go
@@ -22,8 +22,9 @@ func RenderAll(templates map[string]string, variables Variables) (map[string]str
 
 func Render(templateString string, variables Variables) (string, error) {
 	funcMap := template.FuncMap{
-		"ToUpper": strings.ToUpper,
-		"ToLower": strings.ToLower,
+		"ToUpper":    strings.ToUpper,
+		"ToLower":    strings.ToLower,
+		"Identifier": IdentifierFunc,
 	}
 
 	t, err := template.


### PR DESCRIPTION
Adds a template function, so random strings can safely used for `meta.name`.