### PR TITLE
initialize seed

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,10 +2,16 @@ package main
 
 import (
 	"fmt"
+	"math/rand"
 	"os"
+	"time"
 
 	"github.com/rebuy-de/kubernetes-deployment/cmd"
 )
+
+func init() {
+	rand.Seed(time.Now().UTC().UnixNano())
+}
 
 func main() {
 	if err := cmd.NewRootCommand().Execute(); err != nil {


### PR DESCRIPTION
Apparently golang always initializes seed with `1`.

@rebuy-de/prp-kubernetes-deployment Please review.