### PR TITLE
refactor api package

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -19,10 +19,7 @@ func NewApplyCommand(params *api.Parameters) *cobra.Command {
 		}
 
 		app, err := api.New(params)
-		if err != nil {
-			log.Fatal(err)
-			return nil
-		}
+		checkError(err)
 
 		log.WithFields(log.Fields{
 			"Project": project,
@@ -30,10 +27,7 @@ func NewApplyCommand(params *api.Parameters) *cobra.Command {
 		}).Info("deploying project")
 
 		err = app.Apply(project, branch)
-		if err != nil {
-			log.Fatal(err)
-			return nil
-		}
+		checkError(err)
 
 		log.WithFields(log.Fields{
 			"Project": project,

--- a/cmd/dump_config.go
+++ b/cmd/dump_config.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -19,10 +18,7 @@ func NewDumpConfigCommand() *cobra.Command {
 		all := viper.AllSettings()
 
 		raw, err := json.MarshalIndent(all, "", "    ")
-		if err != nil {
-			log.Fatal(err)
-			return
-		}
+		checkError(err)
 		fmt.Println(string(raw))
 	}
 

--- a/cmd/dump_settings.go
+++ b/cmd/dump_settings.go
@@ -6,7 +6,6 @@ import (
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/rebuy-de/kubernetes-deployment/pkg/api"
-	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -18,18 +17,12 @@ func NewDumpSettingsCommand(params *api.Parameters) *cobra.Command {
 
 	cmd.Run = func(cmd *cobra.Command, args []string) {
 		app, err := api.New(params)
-		if err != nil {
-			log.Fatal(err)
-			return
-		}
+		checkError(err)
 
 		app.Settings.Clean(app.Parameters.Context)
 
 		raw, err := yaml.Marshal(app.Settings)
-		if err != nil {
-			log.Fatal(err)
-			return
-		}
+		checkError(err)
 		fmt.Println(string(raw))
 	}
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -22,10 +22,7 @@ func NewGenerateCommand(params *api.Parameters) *cobra.Command {
 		}
 
 		app, err := api.New(params)
-		if err != nil {
-			log.Fatal(err)
-			return nil
-		}
+		checkError(err)
 
 		log.WithFields(log.Fields{
 			"Project": project,
@@ -33,17 +30,11 @@ func NewGenerateCommand(params *api.Parameters) *cobra.Command {
 		}).Info("generating manifests")
 
 		objects, err := app.Generate(project, branch)
-		if err != nil {
-			log.Fatal(err)
-			return nil
-		}
+		checkError(err)
 
 		for _, obj := range objects {
 			raw, err := json.MarshalIndent(obj, "", "    ")
-			if err != nil {
-				log.Fatal(err)
-				return nil
-			}
+			checkError(err)
 			fmt.Println(string(raw))
 		}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"fmt"
 	"math/rand"
+
+	log "github.com/sirupsen/logrus"
 )
 
 const (
@@ -34,4 +36,19 @@ func randomID() string {
 		b[i] = letters[rand.Intn(len(letters))]
 	}
 	return string(b)
+}
+
+type Exit struct{ Code int }
+
+func checkError(err error) {
+	if err == nil {
+		return
+	}
+
+	log.WithFields(log.Fields{
+		"StackTrace": fmt.Sprintf("%+v", err),
+	}).Debug("a fatal error occured")
+	log.Error(err)
+
+	panic(Exit{1})
 }

--- a/main.go
+++ b/main.go
@@ -13,7 +13,17 @@ func init() {
 	rand.Seed(time.Now().UTC().UnixNano())
 }
 
+func handleExit() {
+	if e := recover(); e != nil {
+		if exit, ok := e.(cmd.Exit); ok == true {
+			os.Exit(exit.Code)
+		}
+		panic(e) // not an Exit, bubble up
+	}
+}
+
 func main() {
+	defer handleExit()
 	if err := cmd.NewRootCommand().Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(-1)

--- a/pkg/api/app.go
+++ b/pkg/api/app.go
@@ -8,9 +8,9 @@ import (
 )
 
 type Clients struct {
-	GitHub     gh.Client
-	Kubernetes kubectl.Interface
-	Statsd     statsdw.Interface
+	GitHub  gh.Interface
+	Kubectl kubectl.Interface
+	Statsd  statsdw.Interface
 }
 
 type App struct {
@@ -32,7 +32,7 @@ func New(p *Parameters) (*App, error) {
 		return nil, err
 	}
 	app.Clients.GitHub = gh.New(p.GitHubToken, p.HTTPCacheDir, app.Clients.Statsd)
-	app.Clients.Kubernetes = kubectl.New(p.KubectlPath, p.Kubeconfig)
+	app.Clients.Kubectl = kubectl.New(p.KubectlPath, p.Kubeconfig)
 
 	app.Settings, err = settings.Read(p.Filename, app.Clients.GitHub)
 	if err != nil {

--- a/pkg/api/apply.go
+++ b/pkg/api/apply.go
@@ -22,7 +22,7 @@ func (app *App) Apply(project, branchName string) error {
 	}
 
 	for _, obj := range objects {
-		err = app.Clients.Kubernetes.Apply(obj)
+		err = app.Clients.Kubectl.Apply(obj)
 		if err != nil {
 			return errors.Wrap(err, "unable to apply manifest")
 		}

--- a/pkg/api/fetch.go
+++ b/pkg/api/fetch.go
@@ -1,0 +1,66 @@
+package api
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/structs"
+	"github.com/pkg/errors"
+	"github.com/rebuy-de/kubernetes-deployment/pkg/gh"
+	"github.com/rebuy-de/kubernetes-deployment/pkg/settings"
+	log "github.com/sirupsen/logrus"
+)
+
+type FetchResult struct {
+	Branch    *gh.Branch
+	Service   *settings.Service
+	Templates map[string]string
+}
+
+func (app *App) Fetch(project, branchName string) (*FetchResult, error) {
+	log.WithFields(log.Fields{
+		"Project": project,
+		"Branch":  branchName,
+	}).Debugf("fetching templates")
+
+	app.Settings.Clean(app.Parameters.Context)
+
+	service := app.Settings.Service(project)
+	if service == nil {
+		return nil, errors.Errorf("project '%s' not found", project)
+	}
+
+	log.WithFields(
+		log.Fields(structs.Map(service)),
+	).Debug("project found")
+
+	service.Location.Ref = branchName
+
+	branch, err := app.Clients.GitHub.GetBranch(&service.Location)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get branch information")
+	}
+
+	log.WithFields(log.Fields{
+		"Commit": fmt.Sprintf(
+			"commit: %s\n"+
+				"Author: %s\n"+
+				"Date:   %s\n"+
+				"\n%s\n",
+			branch.SHA, branch.Author, branch.Date,
+			strings.Replace(branch.Message, "\n", "\n    ", -1)),
+	}).Debug("fetched latest commit data")
+
+	service.Location.Ref = branch.SHA
+
+	templateStrings, err := app.Clients.GitHub.GetFiles(&service.Location)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return &FetchResult{
+		Branch:    branch,
+		Service:   service,
+		Templates: templateStrings,
+	}, nil
+}

--- a/pkg/api/generate.go
+++ b/pkg/api/generate.go
@@ -1,16 +1,10 @@
 package api
 
 import (
-	"fmt"
-	"strings"
-
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/pkg/api"
 
-	"github.com/fatih/structs"
 	"github.com/pkg/errors"
 	"github.com/rebuy-de/kubernetes-deployment/pkg/statsdw"
-	"github.com/rebuy-de/kubernetes-deployment/pkg/templates"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -24,79 +18,18 @@ func (app *App) Generate(project, branchName string) ([]runtime.Object, error) {
 		statsdw.Tag{"project", project},
 		statsdw.Tag{"branch", branchName})
 
-	app.Settings.Clean(app.Parameters.Context)
-
-	service := app.Settings.Service(project)
-	if service == nil {
-		return nil, errors.Errorf("project '%s' not found", project)
-	}
-
-	log.WithFields(
-		log.Fields(structs.Map(service)),
-	).Debug("project found")
-
-	service.Location.Ref = branchName
-
-	branch, err := app.Clients.GitHub.GetBranch(&service.Location)
+	fetched, err := app.Fetch(project, branchName)
 	if err != nil {
-		return nil, errors.Wrap(err, "Unable to get branch information")
+		return nil, errors.Wrap(err, "failed to fetch project")
 	}
 
-	log.WithFields(log.Fields{
-		"Commit": fmt.Sprintf(
-			"commit: %s\n"+
-				"Author: %s\n"+
-				"Date:   %s\n"+
-				"\n%s\n",
-			branch.SHA, branch.Author, branch.Date,
-			strings.Replace(branch.Message, "\n", "\n    ", -1)),
-	}).Debug("fetched latest commit data")
-
-	service.Location.Ref = branch.SHA
-
-	templateStrings, err := app.Clients.GitHub.GetFiles(&service.Location)
+	objects, err := app.Render(fetched)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, errors.Wrap(err, "failed to render project")
 	}
 
-	defaultVariables := templates.Variables{
-		"gitBranchName": branch.Name,
-		"gitCommitID":   branch.SHA,
-	}
-
-	service.Variables.Defaults(defaultVariables)
-
-	log.WithFields(log.Fields{
-		"Values": service.Variables,
-	}).Debug("collected template values")
-
-	rendered, err := templates.RenderAll(templateStrings, service.Variables)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	decode := api.Codecs.UniversalDeserializer().Decode
-
-	objects := []runtime.Object{}
-
-	for name, data := range rendered {
-		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
-			log.WithFields(log.Fields{
-				"Name": name,
-			}).Debug("Ignoring file with wrong extension.")
-			continue
-		}
-
-		obj, _, err := decode([]byte(data), nil, nil)
-		if err != nil {
-			return nil, errors.Wrapf(err, "unable to decode file '%s'", name)
-		}
-
-		objects = append(objects, obj)
-	}
-
-	if len(rendered) <= 0 {
-		return nil, errors.Errorf("directory doesn't contain any template files")
+	if len(objects) <= 0 {
+		return nil, errors.Errorf("didn't find any template files")
 	}
 
 	return objects, nil

--- a/pkg/api/generate_test.go
+++ b/pkg/api/generate_test.go
@@ -72,7 +72,7 @@ func TestProjectNoExist(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 
-	expect := "project 'project-no-exist' not found"
+	expect := "failed to fetch project: project 'project-no-exist' not found"
 	if err.Error() != expect {
 		t.Errorf("Got wrong error:")
 		t.Errorf("  Expected: %s", expect)
@@ -88,7 +88,7 @@ func TestMissingRepo(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 
-	expect := "Unable to get branch information: fake repo 'rebuy-de/repo-no-exist' doesn't exist"
+	expect := "failed to fetch project: unable to get branch information: fake repo 'rebuy-de/repo-no-exist' doesn't exist"
 	if err.Error() != expect {
 		t.Errorf("Got wrong error:")
 		t.Errorf("  Expected: %s", expect)
@@ -104,7 +104,7 @@ func TestMissingBranch(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 
-	expect := "Unable to get branch information: fake branch 'rebuy-de/foobar#missing-branch' doesn't exist"
+	expect := "failed to fetch project: unable to get branch information: fake branch 'rebuy-de/foobar#missing-branch' doesn't exist"
 	if err.Error() != expect {
 		t.Errorf("Got wrong error:")
 		t.Errorf("  Expected: %s", expect)
@@ -120,7 +120,7 @@ func TestMissingFiles(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 
-	expect := "directory doesn't contain any template files"
+	expect := "didn't find any template files"
 	if err.Error() != expect {
 		t.Errorf("Got wrong error:")
 		t.Errorf("  Expected: %s", expect)
@@ -136,7 +136,7 @@ func TestInvalidFile(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 
-	expect := "unable to decode file 'invalid.yaml': "
+	expect := `failed to render project: unable to decode file 'invalid.yaml': couldn't get version/kind; json parse error: json: cannot unmarshal array into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }`
 	if !strings.HasPrefix(err.Error(), expect) {
 		t.Errorf("Got wrong error:")
 		t.Errorf("  Expected prefix:  %s", expect)

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -1,0 +1,51 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/rebuy-de/kubernetes-deployment/pkg/templates"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/pkg/api"
+)
+
+func (app *App) Render(fetched *FetchResult) ([]runtime.Object, error) {
+	defaultVariables := templates.Variables{
+		"gitBranchName": fetched.Branch.Name,
+		"gitCommitID":   fetched.Branch.SHA,
+	}
+
+	fetched.Service.Variables.Defaults(defaultVariables)
+
+	log.WithFields(log.Fields{
+		"Values": fetched.Service.Variables,
+	}).Debug("collected template values")
+
+	rendered, err := templates.RenderAll(fetched.Templates, fetched.Service.Variables)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	decode := api.Codecs.UniversalDeserializer().Decode
+
+	objects := []runtime.Object{}
+
+	for name, data := range rendered {
+		if !strings.HasSuffix(name, ".yaml") && !strings.HasSuffix(name, ".yml") {
+			log.WithFields(log.Fields{
+				"Name": name,
+			}).Debug("Ignoring file with wrong extension.")
+			continue
+		}
+
+		obj, _, err := decode([]byte(data), nil, nil)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to decode file '%s'", name)
+		}
+
+		objects = append(objects, obj)
+	}
+
+	return objects, nil
+}

--- a/pkg/gh/client.go
+++ b/pkg/gh/client.go
@@ -22,7 +22,7 @@ var (
 	ContentLocationRE = regexp.MustCompile(`^github.com/([^/]+)/([^/]+)/(.*)$`)
 )
 
-type Client interface {
+type Interface interface {
 	GetBranch(location *Location) (*Branch, error)
 	GetFile(location *Location) (string, error)
 	GetFiles(location *Location) (map[string]string, error)
@@ -33,7 +33,7 @@ type API struct {
 	statsd statsdw.Interface
 }
 
-func New(token string, cacheDir string, statsd statsdw.Interface) Client {
+func New(token string, cacheDir string, statsd statsdw.Interface) Interface {
 	ctx := context.Background()
 	ts := oauth2.StaticTokenSource(
 		&oauth2.Token{AccessToken: token},

--- a/pkg/gh/fake/package_test.go
+++ b/pkg/gh/fake/package_test.go
@@ -16,7 +16,7 @@ var (
 		Message: "dis is a test",
 	}
 
-	Example gh.Client = &GitHub{
+	Example gh.Interface = &GitHub{
 		"rebuy-de": Repos{
 			"info": Branches{
 				"master": Branch{

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -48,7 +48,7 @@ func FromBytes(data []byte) (*Settings, error) {
 	return config, nil
 }
 
-func Read(location string, client gh.Client) (*Settings, error) {
+func Read(location string, client gh.Interface) (*Settings, error) {
 	if strings.HasPrefix(location, "github.com") {
 		return ReadFromGitHub(location, client)
 	} else {
@@ -66,7 +66,7 @@ func ReadFromFile(filename string) (*Settings, error) {
 
 }
 
-func ReadFromGitHub(filename string, client gh.Client) (*Settings, error) {
+func ReadFromGitHub(filename string, client gh.Interface) (*Settings, error) {
 	location, err := gh.NewLocation(filename)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parse GitHub location '%s'; use './' prefix to use a directory named 'github.com'", filename)


### PR DESCRIPTION
I did some refactoring:

* I divided the `Generate` function into multiple part, because it got a bit long. Also we need to add additional functionality to this function later, which would make it even bigger.
* I refactored the error handling a bit. Now there is an additional debug log entry with the [stack trace](https://github.com/pkg/errors). Also I had to create a wrapper function with does a panic on errors, because `os.Exit()` [doesn't honor deferrers](https://stackoverflow.com/questions/27629380/how-to-exit-a-go-program-honoring-deferred-calls).