### PR TITLE
add preStop sleep

### DIFF
--- a/pkg/api/app.go
+++ b/pkg/api/app.go
@@ -4,6 +4,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rebuy-de/kubernetes-deployment/pkg/gh"
 	"github.com/rebuy-de/kubernetes-deployment/pkg/interceptors"
+	"github.com/rebuy-de/kubernetes-deployment/pkg/interceptors/prestopsleep"
 	"github.com/rebuy-de/kubernetes-deployment/pkg/interceptors/rmresspec"
 	"github.com/rebuy-de/kubernetes-deployment/pkg/interceptors/waiter"
 	"github.com/rebuy-de/kubernetes-deployment/pkg/kubectl"
@@ -51,6 +52,7 @@ func New(p *Parameters) (*App, error) {
 
 	app.Interceptors = interceptors.New(
 		waiter.NewDeploymentWaitInterceptor(app.Clients.Kubernetes),
+		prestopsleep.New(),
 	)
 
 	if app.CurrentContext().RemoveResourceSpecs {

--- a/pkg/interceptors/prestopsleep/interceptor.go
+++ b/pkg/interceptors/prestopsleep/interceptor.go
@@ -1,0 +1,69 @@
+package prestopsleep
+
+import (
+	"fmt"
+	"reflect"
+
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/pkg/api/v1"
+	v1beta1apps "k8s.io/client-go/pkg/apis/apps/v1beta1"
+	v1beta1extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+const SleepSeconds = 5
+
+type Interceptor struct {
+}
+
+func New() *Interceptor {
+	return &Interceptor{}
+}
+
+func (i *Interceptor) ManifestRendered(obj runtime.Object) (runtime.Object, error) {
+	switch typed := obj.(type) {
+	case *v1beta1extensions.Deployment:
+		AddToDeployment(typed)
+		return typed, nil
+
+	case *v1beta1apps.StatefulSet:
+		AddToStatefulSet(typed)
+		return typed, nil
+
+	default:
+		log.WithFields(log.Fields{
+			"type": reflect.TypeOf(obj),
+		}).Debug("type doesn't support adding preStop hook")
+	}
+	return obj, nil
+}
+
+func AddToContainer(container *v1.Container) {
+	if container.Lifecycle == nil {
+		container.Lifecycle = &v1.Lifecycle{}
+	}
+
+	if container.Lifecycle.PreStop != nil {
+		return
+	}
+
+	container.Lifecycle.PreStop = &v1.Handler{
+		Exec: &v1.ExecAction{
+			Command: []string{"sleep", fmt.Sprintf("%d", SleepSeconds)},
+		},
+	}
+}
+
+func AddToPodTemplace(tpl *v1.PodTemplateSpec) {
+	for i := range tpl.Spec.Containers {
+		AddToContainer(&tpl.Spec.Containers[i])
+	}
+}
+
+func AddToDeployment(deployment *v1beta1extensions.Deployment) {
+	AddToPodTemplace(&deployment.Spec.Template)
+}
+
+func AddToStatefulSet(set *v1beta1apps.StatefulSet) {
+	AddToPodTemplace(&set.Spec.Template)
+}

--- a/pkg/interceptors/prestopsleep/interceptors_test.go
+++ b/pkg/interceptors/prestopsleep/interceptors_test.go
@@ -1,0 +1,37 @@
+package prestopsleep
+
+import (
+	"testing"
+
+	"github.com/rebuy-de/kubernetes-deployment/pkg/interceptors"
+	"github.com/rebuy-de/kubernetes-deployment/pkg/testutil"
+	"k8s.io/client-go/pkg/api/v1"
+	v1beta1extensions "k8s.io/client-go/pkg/apis/extensions/v1beta1"
+)
+
+func TestType(t *testing.T) {
+	var inter interceptors.ManifestRendered
+	inter = New()
+	_ = inter
+}
+
+func TestModify(t *testing.T) {
+	deployment := &v1beta1extensions.Deployment{
+		Spec: v1beta1extensions.DeploymentSpec{
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					InitContainers: []v1.Container{
+						v1.Container{},
+					},
+					Containers: []v1.Container{
+						v1.Container{},
+						v1.Container{},
+					},
+				},
+			},
+		},
+	}
+	AddToDeployment(deployment)
+
+	testutil.AssertGoldenFile(t, "test-fixtures/deployment-golden.json", deployment)
+}

--- a/pkg/interceptors/prestopsleep/test-fixtures/deployment-golden.json
+++ b/pkg/interceptors/prestopsleep/test-fixtures/deployment-golden.json
@@ -1,0 +1,52 @@
+{
+    "metadata": {
+        "creationTimestamp": null
+    },
+    "spec": {
+        "template": {
+            "metadata": {
+                "creationTimestamp": null
+            },
+            "spec": {
+                "initContainers": [
+                    {
+                        "name": "",
+                        "resources": {}
+                    }
+                ],
+                "containers": [
+                    {
+                        "name": "",
+                        "resources": {},
+                        "lifecycle": {
+                            "preStop": {
+                                "exec": {
+                                    "command": [
+                                        "sleep",
+                                        "5"
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    {
+                        "name": "",
+                        "resources": {},
+                        "lifecycle": {
+                            "preStop": {
+                                "exec": {
+                                    "command": [
+                                        "sleep",
+                                        "5"
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "strategy": {}
+    },
+    "status": {}
+}


### PR DESCRIPTION
Adds a preStop sleep for all containers which don't already have preStop hook. I hardcoded one second. This should be enough and I am too lazy do make it configurable right now.

@rebuy-de/prp-kubernetes-deployment Please review.