### PR TITLE
make golden files more clean

### DIFF
--- a/pkg/gh/location.go
+++ b/pkg/gh/location.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Location struct {
-	Owner, Repo, Path, Ref string
+	Owner, Repo, Path, Ref string `yaml:",omitempty"`
 }
 
 func NewLocation(location string) (*Location, error) {

--- a/pkg/settings/service.go
+++ b/pkg/settings/service.go
@@ -7,6 +7,6 @@ import (
 
 type Service struct {
 	Name      string              `yaml:"name,omitempty"`
-	Location  gh.Location         `yaml:",inline"`
-	Variables templates.Variables `yaml:"variables"`
+	Location  gh.Location         `yaml:",inline,omitempty"`
+	Variables templates.Variables `yaml:"variables,omitempty"`
 }

--- a/pkg/settings/test-fixtures/services-clean-golden.yaml
+++ b/pkg/settings/test-fixtures/services-clean-golden.yaml
@@ -1,8 +1,6 @@
 defaults:
   owner: rebuy-de
-  repo: ""
   path: deployment/k8s/
-  ref: ""
   variables:
     clusterDomain: unit-test.example.org
     secret: foo

--- a/pkg/settings/test-fixtures/services-context-golden.yaml
+++ b/pkg/settings/test-fixtures/services-context-golden.yaml
@@ -1,8 +1,6 @@
 defaults:
   owner: rebuy-de
-  repo: ""
   path: deployment/k8s/
-  ref: ""
   variables:
     clusterDomain: unit-test.example.org
     secret: foo

--- a/pkg/settings/test-fixtures/services-plain-golden.yaml
+++ b/pkg/settings/test-fixtures/services-plain-golden.yaml
@@ -1,45 +1,23 @@
 defaults:
   owner: rebuy-de
-  repo: ""
   path: deployment/k8s/
-  ref: ""
   variables:
     clusterDomain: unit-test.example.org
     secret: foo
   context: abc
 services:
-- owner: ""
-  repo: bish
-  path: ""
-  ref: ""
-  variables: {}
-- owner: ""
-  repo: bash
-  path: ""
-  ref: ""
+- repo: bish
+- repo: bash
   variables:
     clusterDomain: test.example.com
-- owner: ""
-  repo: bosh
+- repo: bosh
   path: //deployment/foo
-  ref: ""
-  variables: {}
 - name: foo
-  owner: ""
   repo: bar
-  path: ""
-  ref: ""
-  variables: {}
 - owner: kubernetes
   repo: blub
-  path: ""
-  ref: ""
-  variables: {}
-- owner: ""
-  repo: meh
+- repo: meh
   path: deployment/k8s
-  ref: ""
-  variables: {}
 contexts:
   abc:
     variables:


### PR DESCRIPTION
Use `omitempty` for all YAML fields, so the golden files are less cluttered.

@rebuy-de/prp-kubernetes-deployment Please review.