### PR TITLE
Generalize pkg/settings

### DIFF
--- a/pkg/api/app.go
+++ b/pkg/api/app.go
@@ -62,7 +62,7 @@ func New(p *Parameters) (*App, error) {
 	return app, nil
 }
 
-func (app *App) CurrentContext() settings.Context {
+func (app *App) CurrentContext() settings.Service {
 	contextName := app.Parameters.Context
 	if contextName == "" {
 		contextName = app.Settings.Defaults.Context

--- a/pkg/gh/location.go
+++ b/pkg/gh/location.go
@@ -2,6 +2,8 @@ package gh
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	"github.com/imdario/mergo"
 	"github.com/pkg/errors"
@@ -32,4 +34,8 @@ func (l Location) String() string {
 
 func (l *Location) Defaults(defaults Location) {
 	mergo.Merge(l, defaults)
+}
+
+func (l *Location) Clean() {
+	l.Path = filepath.Clean(strings.Trim(l.Path, "/")) + "/"
 }

--- a/pkg/settings/default.go
+++ b/pkg/settings/default.go
@@ -1,0 +1,12 @@
+package settings
+
+import "github.com/rebuy-de/kubernetes-deployment/pkg/gh"
+
+var (
+	Defaults = Service{
+		Context: "default",
+		Location: gh.Location{
+			Ref: "master",
+		},
+	}
+)

--- a/pkg/settings/service.go
+++ b/pkg/settings/service.go
@@ -1,12 +1,19 @@
 package settings
 
 import (
+	"github.com/imdario/mergo"
 	"github.com/rebuy-de/kubernetes-deployment/pkg/gh"
 	"github.com/rebuy-de/kubernetes-deployment/pkg/templates"
 )
 
 type Service struct {
-	Name      string              `yaml:"name,omitempty"`
-	Location  gh.Location         `yaml:",inline,omitempty"`
-	Variables templates.Variables `yaml:"variables,omitempty"`
+	Name                string              `yaml:"name,omitempty"`
+	Context             string              `yaml:"context,omitempty"`
+	Location            gh.Location         `yaml:",inline,omitempty"`
+	Variables           templates.Variables `yaml:"variables,omitempty"`
+	RemoveResourceSpecs bool                `yaml:"removeResourceSpecs,omitempty"` // deprecated
+}
+
+func (s *Service) Defaults(defaults Service) {
+	mergo.Merge(s, defaults)
 }

--- a/pkg/settings/service.go
+++ b/pkg/settings/service.go
@@ -16,4 +16,9 @@ type Service struct {
 
 func (s *Service) Defaults(defaults Service) {
 	mergo.Merge(s, defaults)
+	s.Clean()
+}
+
+func (s *Service) Clean() {
+	s.Location.Clean()
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rebuy-de/kubernetes-deployment/pkg/gh"
-	"github.com/rebuy-de/kubernetes-deployment/pkg/templates"
 
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
@@ -20,21 +19,10 @@ var (
 	DefaultContext = "default"
 )
 
-type Defaults struct {
-	Location  gh.Location         `yaml:",inline"`
-	Variables templates.Variables `yaml:"variables"`
-	Context   string              `yaml:"context"`
-}
-
-type Contexts map[string]Context
-
-type Context struct {
-	Variables           templates.Variables `yaml:"variables"`
-	RemoveResourceSpecs bool                `yaml:"removeResourceSpecs,omitempty"`
-}
+type Contexts map[string]Service
 
 type Settings struct {
-	Defaults Defaults `yaml:"defaults"`
+	Defaults Service  `yaml:"defaults"`
 	Services Services `yaml:"services"`
 	Contexts Contexts `yaml:"contexts"`
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -84,6 +84,7 @@ func (s *Settings) Clean(contextName string) {
 	for name := range s.Contexts {
 		context := s.Contexts[name]
 		context.Defaults(s.Defaults)
+		context.Context = name
 		s.Contexts[name] = context
 	}
 

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -2,7 +2,6 @@ package settings
 
 import (
 	"io/ioutil"
-	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -10,13 +9,6 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
-)
-
-var (
-	DefaultLocation = gh.Location{
-		Ref: "master",
-	}
-	DefaultContext = "default"
 )
 
 type Contexts map[string]Service
@@ -87,24 +79,19 @@ func (s *Settings) Clean(contextName string) {
 		"Context": contextName,
 	}).Debug("cleaning settings file")
 
-	s.Defaults.Location.Path = filepath.Clean(strings.Trim(s.Defaults.Location.Path, "/")) + "/"
+	s.Defaults.Defaults(Defaults)
 
 	for name := range s.Contexts {
 		context := s.Contexts[name]
-		context.Variables.Defaults(s.Defaults.Variables)
+		context.Defaults(s.Defaults)
+		s.Contexts[name] = context
 	}
 
 	context := s.Contexts[contextName]
 
 	for i := range s.Services {
 		service := &s.Services[i]
-
-		service.Location.Defaults(s.Defaults.Location)
-		service.Location.Defaults(DefaultLocation)
-
-		service.Variables.Defaults(context.Variables)
-
-		service.Location.Path = filepath.Clean(strings.Trim(service.Location.Path, "/")) + "/"
+		service.Defaults(context)
 
 		if strings.TrimSpace(service.Name) == "" {
 			nameParts := []string{}

--- a/pkg/settings/test-fixtures/services-clean-golden.yaml
+++ b/pkg/settings/test-fixtures/services-clean-golden.yaml
@@ -2,11 +2,13 @@ defaults:
   context: abc
   owner: rebuy-de
   path: deployment/k8s/
+  ref: master
   variables:
     clusterDomain: unit-test.example.org
     secret: foo
 services:
 - name: bish
+  context: abc
   owner: rebuy-de
   repo: bish
   path: deployment/k8s/
@@ -16,6 +18,7 @@ services:
     clusterDomain: unit-test.example.org
     secret: foo
 - name: bash
+  context: abc
   owner: rebuy-de
   repo: bash
   path: deployment/k8s/
@@ -25,6 +28,7 @@ services:
     clusterDomain: test.example.com
     secret: foo
 - name: bosh-deployment-foo
+  context: abc
   owner: rebuy-de
   repo: bosh
   path: deployment/foo/
@@ -34,6 +38,7 @@ services:
     clusterDomain: unit-test.example.org
     secret: foo
 - name: foo
+  context: abc
   owner: rebuy-de
   repo: bar
   path: deployment/k8s/
@@ -43,6 +48,7 @@ services:
     clusterDomain: unit-test.example.org
     secret: foo
 - name: kubernetes-blub
+  context: abc
   owner: kubernetes
   repo: blub
   path: deployment/k8s/
@@ -52,6 +58,7 @@ services:
     clusterDomain: unit-test.example.org
     secret: foo
 - name: meh
+  context: abc
   owner: rebuy-de
   repo: meh
   path: deployment/k8s/
@@ -62,11 +69,19 @@ services:
     secret: foo
 contexts:
   abc:
+    context: abc
+    owner: rebuy-de
+    path: deployment/k8s/
+    ref: master
     variables:
       bish: bash
       clusterDomain: unit-test.example.org
       secret: foo
   def:
+    context: abc
+    owner: rebuy-de
+    path: deployment/k8s/
+    ref: master
     variables:
       bish: bosh
       clusterDomain: unit-test.example.org

--- a/pkg/settings/test-fixtures/services-clean-golden.yaml
+++ b/pkg/settings/test-fixtures/services-clean-golden.yaml
@@ -1,10 +1,10 @@
 defaults:
+  context: abc
   owner: rebuy-de
   path: deployment/k8s/
   variables:
     clusterDomain: unit-test.example.org
     secret: foo
-  context: abc
 services:
 - name: bish
   owner: rebuy-de

--- a/pkg/settings/test-fixtures/services-clean-golden.yaml
+++ b/pkg/settings/test-fixtures/services-clean-golden.yaml
@@ -78,7 +78,7 @@ contexts:
       clusterDomain: unit-test.example.org
       secret: foo
   def:
-    context: abc
+    context: def
     owner: rebuy-de
     path: deployment/k8s/
     ref: master

--- a/pkg/settings/test-fixtures/services-context-golden.yaml
+++ b/pkg/settings/test-fixtures/services-context-golden.yaml
@@ -2,11 +2,13 @@ defaults:
   context: abc
   owner: rebuy-de
   path: deployment/k8s/
+  ref: master
   variables:
     clusterDomain: unit-test.example.org
     secret: foo
 services:
 - name: bish
+  context: abc
   owner: rebuy-de
   repo: bish
   path: deployment/k8s/
@@ -15,7 +17,9 @@ services:
     bish: bosh
     clusterDomain: unit-test.example.org
     secret: foo
+  removeResourceSpecs: true
 - name: bash
+  context: abc
   owner: rebuy-de
   repo: bash
   path: deployment/k8s/
@@ -24,7 +28,9 @@ services:
     bish: bosh
     clusterDomain: test.example.com
     secret: foo
+  removeResourceSpecs: true
 - name: bosh-deployment-foo
+  context: abc
   owner: rebuy-de
   repo: bosh
   path: deployment/foo/
@@ -33,7 +39,9 @@ services:
     bish: bosh
     clusterDomain: unit-test.example.org
     secret: foo
+  removeResourceSpecs: true
 - name: foo
+  context: abc
   owner: rebuy-de
   repo: bar
   path: deployment/k8s/
@@ -42,7 +50,9 @@ services:
     bish: bosh
     clusterDomain: unit-test.example.org
     secret: foo
+  removeResourceSpecs: true
 - name: kubernetes-blub
+  context: abc
   owner: kubernetes
   repo: blub
   path: deployment/k8s/
@@ -51,7 +61,9 @@ services:
     bish: bosh
     clusterDomain: unit-test.example.org
     secret: foo
+  removeResourceSpecs: true
 - name: meh
+  context: abc
   owner: rebuy-de
   repo: meh
   path: deployment/k8s/
@@ -60,13 +72,22 @@ services:
     bish: bosh
     clusterDomain: unit-test.example.org
     secret: foo
+  removeResourceSpecs: true
 contexts:
   abc:
+    context: abc
+    owner: rebuy-de
+    path: deployment/k8s/
+    ref: master
     variables:
       bish: bash
       clusterDomain: unit-test.example.org
       secret: foo
   def:
+    context: abc
+    owner: rebuy-de
+    path: deployment/k8s/
+    ref: master
     variables:
       bish: bosh
       clusterDomain: unit-test.example.org

--- a/pkg/settings/test-fixtures/services-context-golden.yaml
+++ b/pkg/settings/test-fixtures/services-context-golden.yaml
@@ -1,10 +1,10 @@
 defaults:
+  context: abc
   owner: rebuy-de
   path: deployment/k8s/
   variables:
     clusterDomain: unit-test.example.org
     secret: foo
-  context: abc
 services:
 - name: bish
   owner: rebuy-de

--- a/pkg/settings/test-fixtures/services-context-golden.yaml
+++ b/pkg/settings/test-fixtures/services-context-golden.yaml
@@ -8,7 +8,7 @@ defaults:
     secret: foo
 services:
 - name: bish
-  context: abc
+  context: def
   owner: rebuy-de
   repo: bish
   path: deployment/k8s/
@@ -19,7 +19,7 @@ services:
     secret: foo
   removeResourceSpecs: true
 - name: bash
-  context: abc
+  context: def
   owner: rebuy-de
   repo: bash
   path: deployment/k8s/
@@ -30,7 +30,7 @@ services:
     secret: foo
   removeResourceSpecs: true
 - name: bosh-deployment-foo
-  context: abc
+  context: def
   owner: rebuy-de
   repo: bosh
   path: deployment/foo/
@@ -41,7 +41,7 @@ services:
     secret: foo
   removeResourceSpecs: true
 - name: foo
-  context: abc
+  context: def
   owner: rebuy-de
   repo: bar
   path: deployment/k8s/
@@ -52,7 +52,7 @@ services:
     secret: foo
   removeResourceSpecs: true
 - name: kubernetes-blub
-  context: abc
+  context: def
   owner: kubernetes
   repo: blub
   path: deployment/k8s/
@@ -63,7 +63,7 @@ services:
     secret: foo
   removeResourceSpecs: true
 - name: meh
-  context: abc
+  context: def
   owner: rebuy-de
   repo: meh
   path: deployment/k8s/
@@ -84,7 +84,7 @@ contexts:
       clusterDomain: unit-test.example.org
       secret: foo
   def:
-    context: abc
+    context: def
     owner: rebuy-de
     path: deployment/k8s/
     ref: master

--- a/pkg/settings/test-fixtures/services-plain-golden.yaml
+++ b/pkg/settings/test-fixtures/services-plain-golden.yaml
@@ -1,10 +1,10 @@
 defaults:
+  context: abc
   owner: rebuy-de
   path: deployment/k8s/
   variables:
     clusterDomain: unit-test.example.org
     secret: foo
-  context: abc
 services:
 - repo: bish
 - repo: bash

--- a/pkg/templates/variables.go
+++ b/pkg/templates/variables.go
@@ -4,6 +4,6 @@ import "github.com/imdario/mergo"
 
 type Variables map[string]string
 
-func (v *Variables) Defaults(defaults Variables) {
+func (v *Variables) Defaults(defaults Variables) { // deprecated
 	mergo.Merge(v, defaults)
 }

--- a/pkg/templates/variables.go
+++ b/pkg/templates/variables.go
@@ -4,6 +4,6 @@ import "github.com/imdario/mergo"
 
 type Variables map[string]string
 
-func (v *Variables) Defaults(defaults Variables) { // deprecated
+func (v *Variables) Defaults(defaults Variables) {
 	mergo.Merge(v, defaults)
 }


### PR DESCRIPTION
This refactored `Settings` in `pkg/settings`, so it uses `Service` everywhere instead of `Defaults` and `Context`. This makes the code cleaner.

The downside is, that someone could define eg `name` in a context or `context` in a service, which doesn't make much sense.

@rebuy-de/prp-kubernetes-deployment Please review.