### PR TITLE
refactor interceptor interface

### DIFF
--- a/pkg/api/apply.go
+++ b/pkg/api/apply.go
@@ -26,7 +26,7 @@ func (app *App) Apply(project, branchName string) error {
 		if err != nil {
 			return errors.Wrap(err, "unable to apply manifest")
 		}
-		err = app.Interceptors.ManifestApplied(upstreamObj)
+		err = app.Interceptors.PreManifestApply(upstreamObj)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -36,7 +36,7 @@ func (app *App) Apply(project, branchName string) error {
 		}).Debug("applied manifest")
 	}
 
-	err = app.Interceptors.AllManifestsApplied(objects)
+	err = app.Interceptors.PostApply(objects)
 	if err != nil {
 		return errors.WithStack(err)
 	}

--- a/pkg/api/render.go
+++ b/pkg/api/render.go
@@ -51,7 +51,7 @@ func (app *App) Render(fetched *FetchResult) ([]runtime.Object, error) {
 			return nil, errors.Wrapf(err, "unable to decode file '%s'", name)
 		}
 
-		obj, err = app.Interceptors.ManifestRendered(obj)
+		obj, err = app.Interceptors.PostManifestRender(obj)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/pkg/interceptors/interfaces.go
+++ b/pkg/interceptors/interfaces.go
@@ -3,21 +3,22 @@ package interceptors
 import "k8s.io/apimachinery/pkg/runtime"
 
 type Interface interface {
-	ManifestApplied
-	AllManifestsApplied
+	PreManifestApplier
+	PostApplier
+	PostManifestRenderer
 	Closer
 }
 
-type ManifestApplied interface {
-	ManifestApplied(runtime.Object) error
+type PreManifestApplier interface {
+	PreManifestApply(runtime.Object) error
 }
 
-type AllManifestsApplied interface {
-	AllManifestsApplied([]runtime.Object) error
+type PostApplier interface {
+	PostApply([]runtime.Object) error
 }
 
-type ManifestRendered interface {
-	ManifestRendered(runtime.Object) (runtime.Object, error)
+type PostManifestRenderer interface {
+	PostManifestRender(runtime.Object) (runtime.Object, error)
 }
 
 type Closer interface {

--- a/pkg/interceptors/multi.go
+++ b/pkg/interceptors/multi.go
@@ -20,14 +20,14 @@ func (m *Multi) Add(interceptors ...interface{}) {
 	m.Interceptors = append(m.Interceptors, interceptors...)
 }
 
-func (m *Multi) ManifestApplied(obj runtime.Object) error {
+func (m *Multi) PreManifestApply(obj runtime.Object) error {
 	for _, i := range m.Interceptors {
-		c, ok := i.(ManifestApplied)
+		c, ok := i.(PreManifestApplier)
 		if !ok {
 			continue
 		}
 
-		err := c.ManifestApplied(obj)
+		err := c.PreManifestApply(obj)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -36,14 +36,14 @@ func (m *Multi) ManifestApplied(obj runtime.Object) error {
 	return nil
 }
 
-func (m *Multi) AllManifestsApplied(objs []runtime.Object) error {
+func (m *Multi) PostApply(objs []runtime.Object) error {
 	for _, i := range m.Interceptors {
-		c, ok := i.(AllManifestsApplied)
+		c, ok := i.(PostApplier)
 		if !ok {
 			continue
 		}
 
-		err := c.AllManifestsApplied(objs)
+		err := c.PostApply(objs)
 		if err != nil {
 			return errors.WithStack(err)
 		}
@@ -52,16 +52,16 @@ func (m *Multi) AllManifestsApplied(objs []runtime.Object) error {
 	return nil
 }
 
-func (m *Multi) ManifestRendered(obj runtime.Object) (runtime.Object, error) {
+func (m *Multi) PostManifestRender(obj runtime.Object) (runtime.Object, error) {
 	var err error
 
 	for _, i := range m.Interceptors {
-		c, ok := i.(ManifestRendered)
+		c, ok := i.(PostManifestRenderer)
 		if !ok {
 			continue
 		}
 
-		obj, err = c.ManifestRendered(obj)
+		obj, err = c.PostManifestRender(obj)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/pkg/interceptors/prestopsleep/interceptor.go
+++ b/pkg/interceptors/prestopsleep/interceptor.go
@@ -21,7 +21,7 @@ func New(sleepSeconds int) *Interceptor {
 	}
 }
 
-func (i *Interceptor) ManifestRendered(obj runtime.Object) (runtime.Object, error) {
+func (i *Interceptor) PostManifestRender(obj runtime.Object) (runtime.Object, error) {
 	switch typed := obj.(type) {
 	case *v1beta1extensions.Deployment:
 		i.AddToDeployment(typed)

--- a/pkg/interceptors/prestopsleep/interceptors_test.go
+++ b/pkg/interceptors/prestopsleep/interceptors_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestType(t *testing.T) {
-	var inter interceptors.ManifestRendered
+	var inter interceptors.PostManifestRenderer
 	inter = New(5)
 	_ = inter
 }

--- a/pkg/interceptors/rmresspec/interceptor.go
+++ b/pkg/interceptors/rmresspec/interceptor.go
@@ -17,7 +17,7 @@ func New() *Interceptor {
 	return &Interceptor{}
 }
 
-func (i *Interceptor) ManifestRendered(obj runtime.Object) (runtime.Object, error) {
+func (i *Interceptor) PostManifestRender(obj runtime.Object) (runtime.Object, error) {
 	switch typed := obj.(type) {
 	case *v1beta1extensions.Deployment:
 		return RemoveFromDeployment(typed), nil

--- a/pkg/interceptors/rmresspec/interceptors_test.go
+++ b/pkg/interceptors/rmresspec/interceptors_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestType(t *testing.T) {
-	var inter interceptors.ManifestRendered
+	var inter interceptors.PostManifestRenderer
 	inter = New()
 	_ = inter
 }


### PR DESCRIPTION
This gives the Interceptor interface a better and more structured naming (see `pkg/interceptors/interfaces.go`). Also it renames the interfaces like recommended in Golang conventions.

@rebuy-de/prp-kubernetes-deployment Please review.