### PR TITLE
move interceptor config to service level

### DIFF
--- a/pkg/api/app.go
+++ b/pkg/api/app.go
@@ -55,9 +55,13 @@ func New(p *Parameters) (*App, error) {
 
 	app.Settings.Clean(p.Context)
 
+	return app, nil
+}
+
+func (app *App) StartInterceptors(service *settings.Service) {
 	app.Interceptors = interceptors.New()
 
-	interceptors := app.CurrentContext().Interceptors
+	interceptors := service.Interceptors
 
 	if interceptors.Waiter.Enabled == settings.Enabled {
 		log.WithFields(log.Fields{
@@ -100,8 +104,6 @@ func New(p *Parameters) (*App, error) {
 			app.Clients.Kubernetes,
 		))
 	}
-
-	return app, nil
 }
 
 func (app *App) CurrentContext() settings.Service {

--- a/pkg/api/fetch.go
+++ b/pkg/api/fetch.go
@@ -59,6 +59,8 @@ func (app *App) Fetch(project, branchName string) (*FetchResult, error) {
 		return nil, errors.WithStack(err)
 	}
 
+	app.StartInterceptors(service)
+
 	err = app.Interceptors.PostFetch(branch)
 	if err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
This makes the interceptors configurable on service level instead of context level. This can for example be used to set `ghStatusChecker` context name to a specific value.