### PR TITLE
add manifest to pod failure logs

### DIFF
--- a/pkg/interceptors/waiter/interceptor.go
+++ b/pkg/interceptors/waiter/interceptor.go
@@ -136,6 +136,7 @@ func (dwi *DeploymentWaitInterceptor) podNotifier(ctx context.Context, rs *v1bet
 			log.WithFields(log.Fields{
 				"Name":      pod.ObjectMeta.Name,
 				"Namespace": pod.ObjectMeta.Namespace,
+				"PodData":   pod,
 			}).Warn(err)
 		}
 	}


### PR DESCRIPTION
It looks like the pod restart warnings aren't working correctly sometimes. We need more log data to verify that.

@rebuy-de/prp-kubernetes-deployment Please review.