### PR TITLE
CLOUD-1266 fix annoying pod restart notifications

### DIFF
--- a/pkg/kubeutil/pods.go
+++ b/pkg/kubeutil/pods.go
@@ -12,6 +12,11 @@ const (
 )
 
 func PodWarnings(pod *v1.Pod) error {
+	if pod.ObjectMeta.DeletionTimestamp != nil {
+		// ignore Pods with pending deletion
+		return nil
+	}
+
 	for _, cs := range pod.Status.InitContainerStatuses {
 		err := containerWarnings(cs)
 		if err != nil {


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-1266

This fixes the restart warnings in HipChat by ignoring Pods, which are in pending deletion.

@rebuy-de/prp-kubernetes-deployment Please review.