### PR TITLE
adds checks for gh token and kubeconfig file path

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,14 @@ func NewRootCommand() *cobra.Command {
 			"Commit":  BuildHash,
 		}).Debugf("kubernetes-deployment started")
 
+		if strings.TrimSpace(params.GitHubToken) == "" {
+			return fmt.Errorf("You have to specify a GitHubToken.")
+		}
+
+		if strings.TrimSpace(params.Kubeconfig) == "" {
+			return fmt.Errorf("You have to specify a path to kubeconfig.")
+		}
+
 		if strings.TrimSpace(params.Filename) == "" {
 			return fmt.Errorf("You have to specify a filename.")
 		}


### PR DESCRIPTION
in root.go there was a check for the existance of github
demplyments.yaml file path, but not for github token or kubeconfig path,
resulting in an unhandled crash if any of the two were absent
this was addressed by putting extra checks and error messages in the
root.go file
@rebuy-de/prp-kubernetes-deployment  please review