### PR TITLE
add support for subdirectories

### DIFF
--- a/pkg/api/fetch.go
+++ b/pkg/api/fetch.go
@@ -24,12 +24,6 @@ func (app *App) Fetch(project, branchName string) (*FetchResult, error) {
 	}).Debugf("fetching templates")
 
 	service := app.Settings.Service(project)
-	if service == nil {
-		service = app.Settings.GuessService(project)
-		log.WithFields(log.Fields{
-			"Service": service,
-		}).Debug("project not found in settings; guessing it")
-	}
 
 	log.WithFields(
 		log.Fields(structs.Map(service)),

--- a/pkg/settings/services.go
+++ b/pkg/settings/services.go
@@ -1,3 +1,22 @@
 package settings
 
 type Services []Service
+
+func (s Services) Get(name string) *Service {
+	for _, service := range s {
+		if service.Name == name {
+			return &service
+		}
+	}
+
+	// second loop, to prioritise names
+	for _, service := range s {
+		for _, alias := range service.Aliases {
+			if alias == name {
+				return &service
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/rebuy-de/kubernetes-deployment/pkg/testutil"
@@ -35,4 +36,39 @@ func TestCleanWithContext(t *testing.T) {
 	settings.Clean("def")
 
 	testutil.AssertGoldenYAML(t, "test-fixtures/services-context-golden.yaml", settings)
+}
+
+func TestServiceGuessing(t *testing.T) {
+	settings, err := Read("./test-fixtures/services.yaml", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	settings.Clean("")
+
+	cases := []struct {
+		input  string
+		result string
+	}{
+		{input: "my-service", result: "github.com/rebuy-de/my-service/deployment/k8s/@master"},
+		{input: "my-service/sub", result: "github.com/rebuy-de/my-service/deployment/k8s/sub/@master"},
+		{input: "bish", result: "github.com/rebuy-de/bish/deployment/k8s/@master"},
+		{input: "guess", result: "github.com/rebuy-de/k8s-guess/other/@master"},
+		{input: "guess/blub", result: "github.com/rebuy-de/k8s-guess/other/blub/@master"},
+		{input: "cloud/prom", result: "github.com/rebuy-de/cloud/prom/@master"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			svc := settings.Service(tc.input)
+
+			want := tc.result
+			have := fmt.Sprint(svc.Location)
+
+			if want != have {
+				t.Errorf("Wrong result.\n\tWant: %s.\n\tHave: %s.", want, have)
+			}
+		})
+	}
+
 }

--- a/pkg/settings/test-fixtures/services-clean-golden.yaml
+++ b/pkg/settings/test-fixtures/services-clean-golden.yaml
@@ -245,6 +245,68 @@ services:
         initialDelay: 20s
         pullInterval: 10s
         notificationInterval: 3m0s
+- name: guess
+  context: abc
+  owner: rebuy-de
+  repo: k8s-guess
+  path: other/
+  ref: master
+  variables:
+    bish: bash
+    clusterDomain: unit-test.example.org
+    secret: foo
+  interceptors:
+    preStopSleep:
+      enabled: true
+      options:
+        seconds: 3
+    removeResourceSpecs:
+      enabled: null
+    removeOldJob:
+      enabled: null
+    waiter:
+      enabled: true
+    annotater:
+      enabled: null
+    ghStatusChecker:
+      enabled: null
+      options:
+        targetUrlRegex: .*
+        contextRegex: .*
+        initialDelay: 20s
+        pullInterval: 10s
+        notificationInterval: 3m0s
+- name: cloud
+  context: abc
+  owner: rebuy-de
+  repo: cloud
+  path: ./
+  ref: master
+  variables:
+    bish: bash
+    clusterDomain: unit-test.example.org
+    secret: foo
+  interceptors:
+    preStopSleep:
+      enabled: true
+      options:
+        seconds: 3
+    removeResourceSpecs:
+      enabled: null
+    removeOldJob:
+      enabled: null
+    waiter:
+      enabled: true
+    annotater:
+      enabled: null
+    ghStatusChecker:
+      enabled: null
+      options:
+        targetUrlRegex: .*
+        contextRegex: .*
+        initialDelay: 20s
+        pullInterval: 10s
+        notificationInterval: 3m0s
 contexts:
   abc:
     context: abc

--- a/pkg/settings/test-fixtures/services-context-golden.yaml
+++ b/pkg/settings/test-fixtures/services-context-golden.yaml
@@ -245,6 +245,68 @@ services:
         initialDelay: 20s
         pullInterval: 10s
         notificationInterval: 3m0s
+- name: guess
+  context: def
+  owner: rebuy-de
+  repo: k8s-guess
+  path: other/
+  ref: master
+  variables:
+    bish: bosh
+    clusterDomain: unit-test.example.org
+    secret: foo
+  interceptors:
+    preStopSleep:
+      enabled: false
+      options:
+        seconds: 3
+    removeResourceSpecs:
+      enabled: true
+    removeOldJob:
+      enabled: null
+    waiter:
+      enabled: true
+    annotater:
+      enabled: null
+    ghStatusChecker:
+      enabled: null
+      options:
+        targetUrlRegex: .*
+        contextRegex: .*
+        initialDelay: 20s
+        pullInterval: 10s
+        notificationInterval: 3m0s
+- name: cloud
+  context: def
+  owner: rebuy-de
+  repo: cloud
+  path: ./
+  ref: master
+  variables:
+    bish: bosh
+    clusterDomain: unit-test.example.org
+    secret: foo
+  interceptors:
+    preStopSleep:
+      enabled: false
+      options:
+        seconds: 3
+    removeResourceSpecs:
+      enabled: true
+    removeOldJob:
+      enabled: null
+    waiter:
+      enabled: true
+    annotater:
+      enabled: null
+    ghStatusChecker:
+      enabled: null
+      options:
+        targetUrlRegex: .*
+        contextRegex: .*
+        initialDelay: 20s
+        pullInterval: 10s
+        notificationInterval: 3m0s
 contexts:
   abc:
     context: abc

--- a/pkg/settings/test-fixtures/services-plain-golden.yaml
+++ b/pkg/settings/test-fixtures/services-plain-golden.yaml
@@ -41,6 +41,12 @@ services:
   path: deployment/k8s
 - name: bim
   repo: aka
+- name: guess
+  repo: k8s-guess
+  path: other
+- name: cloud
+  repo: cloud
+  path: /
 contexts:
   abc:
     variables:

--- a/pkg/settings/test-fixtures/services.yaml
+++ b/pkg/settings/test-fixtures/services.yaml
@@ -43,3 +43,9 @@ services:
   name: bim
   alias:
   - baz
+- name: guess
+  repo: k8s-guess
+  path: other
+- repo: cloud
+  name: cloud
+  path: /


### PR DESCRIPTION
This adds support for subdirectories when guessing the project settings (ie projects that do not have an entry in the `cloud-infrastructure/deployments.yaml` file). This means we could do something like `hubert deploy k8s-elasicsearch/jaeger` and `hubert deploy k8s-elasicsearch/graylog`, which would deploy the files in `github/.../k8s-elasticsearch/deployment/k8s/jaeger/` and `github/.../k8s-elasticsearch/deployment/k8s/graylog`.

Still needs testing.

@rebuy-de/prp-kubernetes-deployment What do you think?