### PR TITLE
annotate every object

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -13,6 +13,12 @@
   revision = "5bd2802263f21d8788851d5305584c82a5c75d7e"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/benbjohnson/clock"
+  packages = ["."]
+  revision = "7dc76406b6d3c05b5f71a86293cbcf3c4ea03b19"
+
+[[projects]]
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
   revision = "782f4967f2dc4564575ca782fe2d04090b5faca8"
@@ -129,10 +135,10 @@
   revision = "bf9dde6d0d2c004a008c27aaee91170c786f6db8"
 
 [[projects]]
+  branch = "master"
   name = "github.com/imdario/mergo"
   packages = ["."]
-  revision = "9d5f1277e9a8ed20c3684bda8fde67c05628518c"
-  version = "v0.3.4"
+  revision = "7045960c0518a75bb33954ac60b3894b6b6c4cf5"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -324,6 +330,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "374b2453d0ae5e26d59403325ddefd5b04c485eeb8883f982f8f9c174c2c3af3"
+  inputs-digest = "4d6cf061ba64168e5107f26df30e5dd8c9ddea7ec095465ced95d5c703def485"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,3 +61,7 @@
 [[constraint]]
   name = "k8s.io/client-go"
   version = "kubernetes-1.8.5"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/benbjohnson/clock"

--- a/pkg/interceptors/annotater/interceptor.go
+++ b/pkg/interceptors/annotater/interceptor.go
@@ -1,22 +1,22 @@
 package annotater
 
 import (
-	"reflect"
+	"github.com/benbjohnson/clock"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/rebuy-de/kubernetes-deployment/pkg/gh"
-	log "github.com/sirupsen/logrus"
-	v1beta1apps "k8s.io/api/apps/v1beta1"
-	v1beta1extensions "k8s.io/api/extensions/v1beta1"
-	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 type Interceptor struct {
+	clock  clock.Clock
 	branch gh.Branch
 }
 
 func New() *Interceptor {
-	return &Interceptor{}
+	return &Interceptor{
+		clock: clock.New(),
+	}
 }
 
 func (i *Interceptor) PostFetch(branch *gh.Branch) error {
@@ -25,27 +25,21 @@ func (i *Interceptor) PostFetch(branch *gh.Branch) error {
 }
 
 func (i *Interceptor) PostManifestRender(obj runtime.Object) (runtime.Object, error) {
-	switch typed := obj.(type) {
-	case *v1beta1extensions.Deployment:
-		i.AddAnnotations(&typed.ObjectMeta)
-
-	case *v1beta1apps.StatefulSet:
-		i.AddAnnotations(&typed.ObjectMeta)
-
-	default:
-		log.WithFields(log.Fields{
-			"type": reflect.TypeOf(obj),
-		}).Debug("type doesn't support adding of annotations")
+	accessor, err := meta.Accessor(obj)
+	if err != nil {
+		return nil, err
 	}
-	return obj, nil
-}
 
-func (i *Interceptor) AddAnnotations(meta *v1meta.ObjectMeta) {
-	meta.SetAnnotations(map[string]string{
+	now := i.clock.Now()
+
+	accessor.SetAnnotations(map[string]string{
+		"rebuy.com/kubernetes-deployment.deployment-date": now.String(),
 		"rebuy.com/kubernetes-deployment.commit-sha":      i.branch.SHA,
 		"rebuy.com/kubernetes-deployment.commit-date":     i.branch.Date.String(),
 		"rebuy.com/kubernetes-deployment.commit-author":   i.branch.Author,
 		"rebuy.com/kubernetes-deployment.commit-message":  i.branch.Message,
 		"rebuy.com/kubernetes-deployment.commit-location": i.branch.Location.String(),
 	})
+
+	return obj, nil
 }

--- a/pkg/interceptors/annotater/test-fixtures/service-golden.json
+++ b/pkg/interceptors/annotater/test-fixtures/service-golden.json
@@ -10,16 +10,8 @@
             "rebuy.com/kubernetes-deployment.deployment-date": "2009-02-13 23:31:30 +0000 UTC"
         }
     },
-    "spec": {
-        "template": {
-            "metadata": {
-                "creationTimestamp": null
-            },
-            "spec": {
-                "containers": null
-            }
-        },
-        "strategy": {}
-    },
-    "status": {}
+    "spec": {},
+    "status": {
+        "loadBalancer": {}
+    }
 }

--- a/pkg/interceptors/annotater/test-fixtures/statefulset-golden.json
+++ b/pkg/interceptors/annotater/test-fixtures/statefulset-golden.json
@@ -19,7 +19,10 @@
                 "containers": null
             }
         },
-        "strategy": {}
+        "serviceName": "",
+        "updateStrategy": {}
     },
-    "status": {}
+    "status": {
+        "replicas": 0
+    }
 }


### PR DESCRIPTION
This annotates every object and not just Daemonsets and Statefulsets. IMO this is the only way to identify stale Kubernetes objects (like old PVCs with 750GiB).

@rebuy-de/prp-kubernetes-deployment Please review.