### PR TITLE
update lockfile

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -330,6 +330,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "4d6cf061ba64168e5107f26df30e5dd8c9ddea7ec095465ced95d5c703def485"
+  inputs-digest = "67e62eb9905deb34c66c82784f035a090efe0a67f7a2f0fa9bd3422098685d33"
   solver-name = "gps-cdcl"
   solver-version = 1


### PR DESCRIPTION
Somehow the lockfile was not up to date, which caused a [dirty](https://github.com/rebuy-de/kubernetes-deployment/releases/tag/v5.8.0) flag in the release binary.

@rebuy-de/prp-kubernetes-deployment Please review.