### PR TITLE
fix date formatting

### DIFF
--- a/pkg/interceptors/annotater/interceptor.go
+++ b/pkg/interceptors/annotater/interceptor.go
@@ -1,7 +1,7 @@
 package annotater
 
 import (
-	"fmt"
+	"time"
 
 	"github.com/benbjohnson/clock"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -11,13 +11,15 @@ import (
 )
 
 type Interceptor struct {
-	clock  clock.Clock
-	branch gh.Branch
+	clock    clock.Clock
+	branch   gh.Branch
+	timezone *time.Location
 }
 
 func New() *Interceptor {
 	return &Interceptor{
-		clock: clock.New(),
+		clock:    clock.New(),
+		timezone: time.Local,
 	}
 }
 
@@ -39,9 +41,9 @@ func (i *Interceptor) PostManifestRender(obj runtime.Object) (runtime.Object, er
 		annotations = map[string]string{}
 	}
 
-	annotations["rebuy.com/kubernetes-deployment.deployment-date"] = fmt.Sprint(now)
+	annotations["rebuy.com/kubernetes-deployment.deployment-date"] = now.In(i.timezone).Format(time.RFC3339Nano)
 	annotations["rebuy.com/kubernetes-deployment.commit-sha"] = i.branch.SHA
-	annotations["rebuy.com/kubernetes-deployment.commit-date"] = fmt.Sprint(i.branch.Date)
+	annotations["rebuy.com/kubernetes-deployment.commit-date"] = i.branch.Date.In(i.timezone).Format(time.RFC3339Nano)
 	annotations["rebuy.com/kubernetes-deployment.commit-author"] = i.branch.Author
 	annotations["rebuy.com/kubernetes-deployment.commit-message"] = i.branch.Message
 	annotations["rebuy.com/kubernetes-deployment.commit-location"] = i.branch.Location.String()

--- a/pkg/interceptors/annotater/interceptors_test.go
+++ b/pkg/interceptors/annotater/interceptors_test.go
@@ -63,6 +63,7 @@ func TestModify(t *testing.T) {
 
 	inter := New()
 	inter.clock = mockClock
+	inter.timezone = time.UTC
 
 	err := inter.PostFetch(&gh.Branch{
 		Author:  "bim baz",

--- a/pkg/interceptors/annotater/test-fixtures/deployment-golden.json
+++ b/pkg/interceptors/annotater/test-fixtures/deployment-golden.json
@@ -3,11 +3,11 @@
         "creationTimestamp": null,
         "annotations": {
             "rebuy.com/kubernetes-deployment.commit-author": "bim baz",
-            "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13 23:31:30 +0000 UTC",
+            "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13T23:31:30Z",
             "rebuy.com/kubernetes-deployment.commit-location": "github.com/rebuy-de/example-silo/deployment/k8s@master",
             "rebuy.com/kubernetes-deployment.commit-message": "fancy feature",
             "rebuy.com/kubernetes-deployment.commit-sha": "1234567890abcdef",
-            "rebuy.com/kubernetes-deployment.deployment-date": "2009-02-13 23:31:30 +0000 UTC"
+            "rebuy.com/kubernetes-deployment.deployment-date": "2009-02-13T23:31:30Z"
         }
     },
     "spec": {

--- a/pkg/interceptors/annotater/test-fixtures/pvc-golden.json
+++ b/pkg/interceptors/annotater/test-fixtures/pvc-golden.json
@@ -3,11 +3,11 @@
         "creationTimestamp": null,
         "annotations": {
             "rebuy.com/kubernetes-deployment.commit-author": "bim baz",
-            "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13 23:31:30 +0000 UTC",
+            "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13T23:31:30Z",
             "rebuy.com/kubernetes-deployment.commit-location": "github.com/rebuy-de/example-silo/deployment/k8s@master",
             "rebuy.com/kubernetes-deployment.commit-message": "fancy feature",
             "rebuy.com/kubernetes-deployment.commit-sha": "1234567890abcdef",
-            "rebuy.com/kubernetes-deployment.deployment-date": "2009-02-13 23:31:30 +0000 UTC",
+            "rebuy.com/kubernetes-deployment.deployment-date": "2009-02-13T23:31:30Z",
             "volume.beta.kubernetes.io/storage-class": "aws-ebs-gp2"
         }
     },

--- a/pkg/interceptors/annotater/test-fixtures/service-golden.json
+++ b/pkg/interceptors/annotater/test-fixtures/service-golden.json
@@ -3,11 +3,11 @@
         "creationTimestamp": null,
         "annotations": {
             "rebuy.com/kubernetes-deployment.commit-author": "bim baz",
-            "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13 23:31:30 +0000 UTC",
+            "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13T23:31:30Z",
             "rebuy.com/kubernetes-deployment.commit-location": "github.com/rebuy-de/example-silo/deployment/k8s@master",
             "rebuy.com/kubernetes-deployment.commit-message": "fancy feature",
             "rebuy.com/kubernetes-deployment.commit-sha": "1234567890abcdef",
-            "rebuy.com/kubernetes-deployment.deployment-date": "2009-02-13 23:31:30 +0000 UTC"
+            "rebuy.com/kubernetes-deployment.deployment-date": "2009-02-13T23:31:30Z"
         }
     },
     "spec": {},

--- a/pkg/interceptors/annotater/test-fixtures/statefulset-golden.json
+++ b/pkg/interceptors/annotater/test-fixtures/statefulset-golden.json
@@ -3,11 +3,11 @@
         "creationTimestamp": null,
         "annotations": {
             "rebuy.com/kubernetes-deployment.commit-author": "bim baz",
-            "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13 23:31:30 +0000 UTC",
+            "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13T23:31:30Z",
             "rebuy.com/kubernetes-deployment.commit-location": "github.com/rebuy-de/example-silo/deployment/k8s@master",
             "rebuy.com/kubernetes-deployment.commit-message": "fancy feature",
             "rebuy.com/kubernetes-deployment.commit-sha": "1234567890abcdef",
-            "rebuy.com/kubernetes-deployment.deployment-date": "2009-02-13 23:31:30 +0000 UTC"
+            "rebuy.com/kubernetes-deployment.deployment-date": "2009-02-13T23:31:30Z"
         }
     },
     "spec": {


### PR DESCRIPTION
`Time.String()` produces a weird debug format that looks like this: `2018-05-31 13:45:04.231590273 +0200 CEST m=+1.509596926`.

Also I had to fiddle around with the time zones because:

1. `deployment-date` and `commit-date` should have the same TZ.
2. Tests should use UTC, because otherwise the golden file would depend on the local time zone.

@rebuy-de/prp-kubernetes-deployment Please review.