### PR TITLE
fix vendoring

### DIFF
--- a/golang.mk
+++ b/golang.mk
@@ -35,7 +35,7 @@ Gopkg.lock: Gopkg.toml
 	touch Gopkg.lock
 
 vendor: Gopkg.lock Gopkg.toml
-	dep ensure
+	dep ensure -vendor-only
 	touch vendor
 
 format:


### PR DESCRIPTION
Travis wants to update the lock file again. Fortunately `dep` has a flag to avoid this.

@rebuy-de/prp-kubernetes-deployment Please review.