### PR TITLE
fix apply for unknown objects

### DIFF
--- a/pkg/api/generate_test.go
+++ b/pkg/api/generate_test.go
@@ -143,7 +143,7 @@ func TestInvalidFile(t *testing.T) {
 		t.Fatal("expected an error")
 	}
 
-	expect := `failed to render project: unable to decode file 'invalid.yaml': couldn't get version/kind; json parse error: json: cannot unmarshal array into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }`
+	expect := `failed to render project: unable to decode manifest: couldn't get version/kind; json parse error: json: cannot unmarshal array into Go value of type struct { APIVersion string "json:\"apiVersion,omitempty\""; Kind string "json:\"kind,omitempty\"" }`
 	if !strings.HasPrefix(err.Error(), expect) {
 		t.Errorf("Got wrong error:")
 		t.Errorf("  Expected prefix:  %s", expect)

--- a/pkg/kubectl/kubectl.go
+++ b/pkg/kubectl/kubectl.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes/scheme"
 
 	"github.com/pkg/errors"
+	"github.com/rebuy-de/kubernetes-deployment/pkg/kubeutil"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -74,7 +74,7 @@ func (k *Kubectl) Apply(obj runtime.Object) (runtime.Object, error) {
 		return nil, errors.WithStack(err)
 	}
 
-	newObj, _, err := scheme.Codecs.UniversalDeserializer().Decode(stdout.Bytes(), nil, nil)
+	newObj, err := kubeutil.Decode(stdout.Bytes())
 	return newObj, errors.Wrapf(err, "failed to decode result json")
 }
 

--- a/pkg/kubeutil/util.go
+++ b/pkg/kubeutil/util.go
@@ -1,7 +1,10 @@
 package kubeutil
 
 import (
+	"github.com/pkg/errors"
 	v1meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
 )
 
 func IsOwner(parent, child v1meta.ObjectMeta) bool {
@@ -11,4 +14,22 @@ func IsOwner(parent, child v1meta.ObjectMeta) bool {
 		}
 	}
 	return false
+}
+
+func Decode(raw []byte) (runtime.Object, error) {
+	decode := scheme.Codecs.UniversalDeserializer().Decode
+	obj, _, err := decode(raw, nil, nil)
+
+	// Fallback to UnknownObject if the API/Kind is not registered, so the
+	// interceptors still work. In case the Kind actually does not exist,
+	// kubectl will fail later anyway.
+	if runtime.IsNotRegisteredError(err) {
+		unknown := new(UnknownObject)
+		obj = unknown
+
+		// Since JSON is a subset of YAML, this works for both.
+		err = unknown.FromYAML(raw)
+	}
+
+	return obj, errors.Wrapf(err, "unable to decode manifest")
 }


### PR DESCRIPTION
kubernetes-deployment also parses the output of `kubectl apply`, therefore we need to use a proper decoder there too.

@rebuy-de/prp-kubernetes-deployment Please review.