### PR TITLE
add name label

### DIFF
--- a/pkg/interceptors/annotater/interceptors_test.go
+++ b/pkg/interceptors/annotater/interceptors_test.go
@@ -36,22 +36,40 @@ func TestModify(t *testing.T) {
 	}{
 		{
 			name: "deployment",
-			obj:  &extensions.Deployment{},
+			obj: &extensions.Deployment{
+				ObjectMeta: meta.ObjectMeta{Name: "deployment"},
+			},
 		},
 		{
 			name: "statefulset",
-			obj:  &apps.StatefulSet{},
+			obj: &apps.StatefulSet{
+				ObjectMeta: meta.ObjectMeta{Name: "statefulset"},
+			},
 		},
 		{
 			name: "service",
-			obj:  &core.Service{},
+			obj: &core.Service{
+				ObjectMeta: meta.ObjectMeta{Name: "service"},
+			},
 		},
 		{
 			name: "pvc",
 			obj: &core.PersistentVolumeClaim{
 				ObjectMeta: meta.ObjectMeta{
+					Name: "pvc",
 					Annotations: map[string]string{
 						"volume.beta.kubernetes.io/storage-class": "aws-ebs-gp2",
+					},
+				},
+			},
+		},
+		{
+			name: "deployment-name",
+			obj: &core.PersistentVolumeClaim{
+				ObjectMeta: meta.ObjectMeta{
+					Name: "deployment-name",
+					Labels: map[string]string{
+						"name": "bish-bash-bosh",
 					},
 				},
 			},

--- a/pkg/interceptors/annotater/test-fixtures/deployment-golden.json
+++ b/pkg/interceptors/annotater/test-fixtures/deployment-golden.json
@@ -1,6 +1,10 @@
 {
     "metadata": {
+        "name": "deployment",
         "creationTimestamp": null,
+        "labels": {
+            "name": "deployment"
+        },
         "annotations": {
             "rebuy.com/kubernetes-deployment.commit-author": "bim baz",
             "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13T23:31:30Z",

--- a/pkg/interceptors/annotater/test-fixtures/deployment-name-golden.json
+++ b/pkg/interceptors/annotater/test-fixtures/deployment-name-golden.json
@@ -1,9 +1,9 @@
 {
     "metadata": {
-        "name": "service",
+        "name": "deployment-name",
         "creationTimestamp": null,
         "labels": {
-            "name": "service"
+            "name": "bish-bash-bosh"
         },
         "annotations": {
             "rebuy.com/kubernetes-deployment.commit-author": "bim baz",
@@ -14,8 +14,8 @@
             "rebuy.com/kubernetes-deployment.deployment-date": "2009-02-13T23:31:30Z"
         }
     },
-    "spec": {},
-    "status": {
-        "loadBalancer": {}
-    }
+    "spec": {
+        "resources": {}
+    },
+    "status": {}
 }

--- a/pkg/interceptors/annotater/test-fixtures/pvc-golden.json
+++ b/pkg/interceptors/annotater/test-fixtures/pvc-golden.json
@@ -1,6 +1,10 @@
 {
     "metadata": {
+        "name": "pvc",
         "creationTimestamp": null,
+        "labels": {
+            "name": "pvc"
+        },
         "annotations": {
             "rebuy.com/kubernetes-deployment.commit-author": "bim baz",
             "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13T23:31:30Z",

--- a/pkg/interceptors/annotater/test-fixtures/statefulset-golden.json
+++ b/pkg/interceptors/annotater/test-fixtures/statefulset-golden.json
@@ -1,6 +1,10 @@
 {
     "metadata": {
+        "name": "statefulset",
         "creationTimestamp": null,
+        "labels": {
+            "name": "statefulset"
+        },
         "annotations": {
             "rebuy.com/kubernetes-deployment.commit-author": "bim baz",
             "rebuy.com/kubernetes-deployment.commit-date": "2009-02-13T23:31:30Z",


### PR DESCRIPTION
This automatically adds a name label to any manifest, which matches the actual manifest name. This gives use better filtering possibilities in Grafana. Especially in the `Workloads`, it would be a bit easier to filter stuff.

Also:

* it does not overwrite existing labels
* it warns if the names do not match, to enforce some consistency

@rebuy-de/prp-kubernetes-deployment Please review.