### PR TITLE
CLOUD-1740 limit linkerd proxy requests

### DIFF
--- a/pkg/interceptors/injector/interceptor.go
+++ b/pkg/interceptors/injector/interceptor.go
@@ -43,6 +43,8 @@ func (i *Interceptor) PostManifestRender(obj runtime.Object) (runtime.Object, er
 	cmd := exec.Command(
 		"linkerd", "inject",
 		"--linkerd-version", "stable-2.1.0",
+		"--proxy-memory", "200Mi",
+		"--proxy-cpu", "100m",
 		"-")
 	cmd.Stdin = bytes.NewBuffer(marshalled)
 	cmd.Stderr = os.Stderr

--- a/pkg/interceptors/injector/interceptor.go
+++ b/pkg/interceptors/injector/interceptor.go
@@ -43,8 +43,8 @@ func (i *Interceptor) PostManifestRender(obj runtime.Object) (runtime.Object, er
 	cmd := exec.Command(
 		"linkerd", "inject",
 		"--linkerd-version", "stable-2.1.0",
-		"--proxy-memory", "200Mi",
-		"--proxy-cpu", "100m",
+		"--proxy-memory", "20Mi",
+		"--proxy-cpu", "35m",
 		"-")
 	cmd.Stdin = bytes.NewBuffer(marshalled)
 	cmd.Stderr = os.Stderr

--- a/pkg/interceptors/injector/test-fixtures/deployment-golden.json
+++ b/pkg/interceptors/injector/test-fixtures/deployment-golden.json
@@ -125,7 +125,12 @@
                                 }
                             }
                         ],
-                        "resources": {},
+                        "resources": {
+                            "requests": {
+                                "cpu": "100m",
+                                "memory": "200Mi"
+                            }
+                        },
                         "livenessProbe": {
                             "httpGet": {
                                 "path": "/metrics",

--- a/pkg/interceptors/injector/test-fixtures/deployment-golden.json
+++ b/pkg/interceptors/injector/test-fixtures/deployment-golden.json
@@ -127,8 +127,8 @@
                         ],
                         "resources": {
                             "requests": {
-                                "cpu": "100m",
-                                "memory": "200Mi"
+                                "cpu": "35m",
+                                "memory": "20Mi"
                             }
                         },
                         "livenessProbe": {


### PR DESCRIPTION
> https://jira.rebuy.de/browse/CLOUD-1740

Values come from [Prometheus](https://prometheus.production.rebuy.cloud/graph?g0.range_input=1h&g0.expr=node_pod_container%3Acontainer_cpu_usage_seconds%3Arate1m%7Bcontainer%3D%22linkerd-proxy%22%7D&g0.tab=0&g1.range_input=1h&g1.expr=node_pod_container%3Acontainer_memory_usage_bytes%3Asum%7Bcontainer%3D%22linkerd-proxy%22%7D&g1.tab=0).

@rebuy-de/prp-kubernetes-deployment Please review.

*Edit:* These are only requests :-/