### PR TITLE
read settings from configmap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ RUN GO111MODULE= go get -u golang.org/x/lint/golint
 
 # Install Linkerd
 RUN set -x \
- && curl -Lo /usr/local/bin/linkerd https://github.com/linkerd/linkerd2/releases/download/stable-2.1.0/linkerd2-cli-stable-2.1.0-linux \
+ && curl -Lo /usr/local/bin/linkerd https://github.com/linkerd/linkerd2/releases/download/edge-19.1.1/linkerd2-cli-edge-19.1.1-linux \
  && sha256sum /usr/local/bin/linkerd \
- && echo "2e8baf093ea38c29c830e32e50688c16ccdf973c76c50beb2b4827647c12fa62  /usr/local/bin/linkerd" | sha256sum -c \
+ && echo "d97f0ec9a28a5f6172a53ae4b481b286a1d0f65790b7e3706c65081deebd4f95  /usr/local/bin/linkerd" | sha256sum -c \
  && chmod +x /usr/local/bin/linkerd \
  && linkerd version --client --api-addr="localhost"
 

--- a/go.mod
+++ b/go.mod
@@ -49,5 +49,6 @@ require (
 	k8s.io/apimachinery v0.0.0-20181130031032-af2f90f9922d
 	k8s.io/client-go v9.0.0+incompatible
 	k8s.io/klog v0.1.0 // indirect
+	k8s.io/kube-openapi v0.0.0-20190115222348-ced9eb3070a5 // indirect
 	sigs.k8s.io/yaml v1.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -140,5 +140,7 @@ k8s.io/client-go v9.0.0+incompatible h1:2kqW3X2xQ9SbFvWZjGEHBLlWc1LG9JIJNXWkuqwd
 k8s.io/client-go v9.0.0+incompatible/go.mod h1:7vJpHMYJwNQCWgzmNV+VYUl1zCObLyodBc8nIyt8L5s=
 k8s.io/klog v0.1.0 h1:I5HMfc/DtuVaGR1KPwUrTc476K8NCqNBldC7H4dYEzk=
 k8s.io/klog v0.1.0/go.mod h1:Gq+BEi5rUBO/HRz0bTSXDUcqjScdoY3a9IHpCEIOOfk=
+k8s.io/kube-openapi v0.0.0-20190115222348-ced9eb3070a5 h1:leiGEauB5/1TE6nQQ9flpPDz6oEEvPLVuj4B4J40dfA=
+k8s.io/kube-openapi v0.0.0-20190115222348-ced9eb3070a5/go.mod h1:BXM9ceUBTj2QnfH2MK1odQs778ajze1RxcmP6S8RVVc=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/api/app.go
+++ b/pkg/api/app.go
@@ -51,7 +51,7 @@ func New(p *Parameters) (*App, error) {
 		return nil, err
 	}
 
-	app.Settings, err = settings.Read(p.Filename, app.Clients.GitHub)
+	app.Settings, err = settings.Read(p.Filename, app.Clients.GitHub, app.Clients.Kubernetes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/interceptors/injector/test-fixtures/deployment-golden.json
+++ b/pkg/interceptors/injector/test-fixtures/deployment-golden.json
@@ -27,7 +27,7 @@
                     "linkerd.io/proxy-deployment": "nginx-deployment"
                 },
                 "annotations": {
-                    "linkerd.io/created-by": "linkerd/cli stable-2.1.0",
+                    "linkerd.io/created-by": "linkerd/cli edge-19.1.1",
                     "linkerd.io/proxy-version": "123"
                 }
             },
@@ -55,7 +55,9 @@
                                     "NET_ADMIN"
                                 ]
                             },
-                            "privileged": false
+                            "privileged": false,
+                            "runAsUser": 0,
+                            "runAsNonRoot": false
                         }
                     }
                 ],

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -2,13 +2,18 @@ package settings
 
 import (
 	"fmt"
+	"io/ioutil"
 	"testing"
+
+	core "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
 
 	"github.com/rebuy-de/rebuy-go-sdk/testutil"
 )
 
 func TestReadFile(t *testing.T) {
-	settings, err := Read("./test-fixtures/services.yaml", nil)
+	settings, err := Read("./test-fixtures/services.yaml", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -16,8 +21,35 @@ func TestReadFile(t *testing.T) {
 	testutil.AssertGoldenYAML(t, "test-fixtures/services-plain-golden.yaml", settings)
 }
 
+func TestReadConfigMap(t *testing.T) {
+	original, err := ioutil.ReadFile("./test-fixtures/services.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cm := &core.ConfigMap{
+		ObjectMeta: meta.ObjectMeta{
+			Name:      "kubernetes-deployment",
+			Namespace: "default",
+		},
+		Data: map[string]string{
+			"settings.yaml": string(original),
+		},
+	}
+
+	kube := fake.NewSimpleClientset(cm)
+	settings, err := Read("/api/v1/namespaces/default/configmaps/kubernetes-deployment", nil, kube)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This uses the same golden file as TestReadFile, but this is fine since
+	// they actually should look the same.
+	testutil.AssertGoldenYAML(t, "test-fixtures/services-plain-golden.yaml", settings)
+}
+
 func TestClean(t *testing.T) {
-	settings, err := Read("./test-fixtures/services.yaml", nil)
+	settings, err := Read("./test-fixtures/services.yaml", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,7 +60,7 @@ func TestClean(t *testing.T) {
 }
 
 func TestCleanWithContext(t *testing.T) {
-	settings, err := Read("./test-fixtures/services.yaml", nil)
+	settings, err := Read("./test-fixtures/services.yaml", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +71,7 @@ func TestCleanWithContext(t *testing.T) {
 }
 
 func TestServiceGuessing(t *testing.T) {
-	settings, err := Read("./test-fixtures/services.yaml", nil)
+	settings, err := Read("./test-fixtures/services.yaml", nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This allows reading the settings from a ConfigMap. It has the advantage, that a client just needs to configure their kubeconfig and does not have to provide a context. This also makes it possible to remove the context from the settings (#129), without having to wait for the kubernetes-deployment-server branch.

Sorry for all these unfocused PRs, but I want to make sure I do not provide a PR with 5k changes at the end.

