### PR TITLE
resolve git sha

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20181024230925-c65c006176ff // indirect
 	github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c // indirect
 	github.com/google/go-github v15.0.0+incompatible
-	github.com/google/go-jsonnet v0.11.2
+	github.com/google/go-jsonnet v0.12.1
 	github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 // indirect
 	github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf // indirect
 	github.com/googleapis/gnostic v0.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c h1:964Od4U6p2jUkFxvCy
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-github v15.0.0+incompatible h1:jlPg2Cpsxb/FyEV/MFiIE9tW/2RAevQNZDPeHbf5a94=
 github.com/google/go-github v15.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
-github.com/google/go-jsonnet v0.11.2 h1:oSCkvGPE72ouWJLOajr4p0clGFCOFmwhqo52faGsudk=
-github.com/google/go-jsonnet v0.11.2/go.mod h1:gVu3UVSfOt5fRFq+dh9duBqXa5905QY8S1QvMNcEIVs=
+github.com/google/go-jsonnet v0.12.1 h1:v0iUm/b4SBz7lR/diMoz9tLAz8lqtnNRKIwMrmU2HEU=
+github.com/google/go-jsonnet v0.12.1/go.mod h1:gVu3UVSfOt5fRFq+dh9duBqXa5905QY8S1QvMNcEIVs=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135 h1:zLTLjkaOFEFIOxY5BWLFLwh+cL8vOBW4XJ2aqLE/Tf0=
 github.com/google/go-querystring v0.0.0-20170111101155-53e6ce116135/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
 github.com/google/gofuzz v0.0.0-20170612174753-24818f796faf h1:+RRA9JqSOZFfKrOeqr2z77+8R2RKyh8PG66dcu1V0ck=

--- a/pkg/api/render_test.go
+++ b/pkg/api/render_test.go
@@ -64,6 +64,12 @@ func TestDecode(t *testing.T) {
 				"unknown-object.jsonnet",
 			},
 		},
+		{
+			name: "resolve-git-sha-jsonnet",
+			files: []string{
+				"render-resolve-git-sha.jsonnet",
+			},
+		},
 	}
 
 	vars := templates.Variables{

--- a/pkg/api/test-fixtures/render-golden-resolve-git-sha-jsonnet.json
+++ b/pkg/api/test-fixtures/render-golden-resolve-git-sha-jsonnet.json
@@ -1,0 +1,23 @@
+[
+    {
+        "kind": "Pod",
+        "apiVersion": "v1",
+        "metadata": {
+            "name": "myapp-pod",
+            "creationTimestamp": null,
+            "labels": {
+                "app": "myapp"
+            }
+        },
+        "spec": {
+            "containers": [
+                {
+                    "name": "myapp-container",
+                    "image": "busybox:5a5369823a2a9a6ad9c241b404be39f802d41d48",
+                    "resources": {}
+                }
+            ]
+        },
+        "status": {}
+    }
+]

--- a/pkg/api/test-fixtures/render-resolve-git-sha.jsonnet
+++ b/pkg/api/test-fixtures/render-resolve-git-sha.jsonnet
@@ -1,0 +1,16 @@
+[
+    {
+        apiVersion: "v1",
+        kind: "Pod",
+        metadata: {
+            name: "myapp-pod",
+            labels: { app: "myapp" },
+        },
+        spec: {
+            containers: [{
+                name: "myapp-container",
+                image: std.format("busybox:%s", std.native("resolveGitSHA")("github.com/rebuy-de/test@master")),
+            }],
+        },
+    },
+]


### PR DESCRIPTION
Adds a native function, that resolves a git SHA from another repository. This can be useful when splitting Dockerfile and deployment manifests.

It works only with Jsonnet and looks like `std.native("resolveGitSHA")("github.com/rebuy-de/test@master")`, which resolves into a string containing the SHA. See changed files in `pkg/api/test-fixtures/` for an full example.

@rebuy-de/prp-kubernetes-deployment Please review.