### PR TITLE
hardcode settings source

### DIFF
--- a/cmd/k26r/app.go
+++ b/cmd/k26r/app.go
@@ -34,23 +34,18 @@ func (app *App) Bind(cmd *cobra.Command) {
 		"authentication token for the GitHub API")
 }
 
-func (app *App) MustReadSettings() *settings.Settings {
-	settings, err := settings.ReadFromFile(app.SettingsFile)
-	cmdutil.Must(err)
-	settings.Clean()
-	return settings
-}
-
 func (app *App) Run(ctx context.Context, cmd *cobra.Command, args []string) {
 	var err error
 
 	api := new(API)
-	api.Settings = app.MustReadSettings()
 	api.GitHub = gh.New(app.GitHubToken, statsdw.NullClient{})
 
 	api.Kubectl = kubectl.New("kubectl", app.Kubeconfig)
 
 	api.Kubernetes, err = newKubernetesClient(app.Kubeconfig)
+	cmdutil.Must(err)
+
+	api.Settings, err = settings.Read(api.Kubernetes)
 	cmdutil.Must(err)
 
 	server := &http.Server{

--- a/cmd/kubernetes-deployment/parameters.go
+++ b/cmd/kubernetes-deployment/parameters.go
@@ -11,7 +11,6 @@ const (
 	FlagKubeconfig    = "kubeconfig"
 	FlagKubectlPath   = "kubectl-path"
 	FlagGitHubToken   = "github-token"
-	FlagFilename      = "filename"
 	FlagGELFAddress   = "gelf-address"
 	FlagStatsdAddress = "statsd-address"
 )
@@ -42,12 +41,6 @@ func BindParameters(cmd *cobra.Command) *api.Parameters {
 		"oauth token for GitHub ($GITHUB_TOKEN)")
 	viper.BindPFlag(FlagGitHubToken, cmd.PersistentFlags().Lookup(FlagGitHubToken))
 	viper.BindEnv(FlagGitHubToken, "GITHUB_TOKEN")
-
-	// filename
-	cmd.PersistentFlags().StringP(
-		FlagFilename, "f", "",
-		"path to service definitions; might start with './' for local file or 'github.com' for files on GitHub")
-	viper.BindPFlag(FlagFilename, cmd.PersistentFlags().Lookup(FlagFilename))
 
 	// gelf address
 	cmd.PersistentFlags().String(

--- a/cmd/kubernetes-deployment/root.go
+++ b/cmd/kubernetes-deployment/root.go
@@ -66,14 +66,9 @@ func NewRootCommand() *cobra.Command {
 			return fmt.Errorf("You have to specify a GitHubToken.")
 		}
 
-		if strings.TrimSpace(params.Filename) == "" {
-			return fmt.Errorf("You have to specify a filename.")
-		}
-
 		log.WithFields(log.Fields{
 			"GitHubToken": fmt.Sprintf("%s****", params.GitHubToken[0:4]),
 			"Kubeconfig":  params.Kubeconfig,
-			"Filename":    params.Filename,
 		}).Debug("config loaded")
 
 		return nil

--- a/pkg/api/app.go
+++ b/pkg/api/app.go
@@ -51,7 +51,7 @@ func New(p *Parameters) (*App, error) {
 		return nil, err
 	}
 
-	app.Settings, err = settings.Read(p.Filename, app.Clients.GitHub, app.Clients.Kubernetes)
+	app.Settings, err = settings.Read(app.Clients.Kubernetes)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/generate_test.go
+++ b/pkg/api/generate_test.go
@@ -2,6 +2,7 @@ package api_test
 
 import (
 	"flag"
+	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -48,7 +49,12 @@ func TestMain(m *testing.M) {
 }
 
 func generateApp(t *testing.T) *api.App {
-	exampleSettings, err := settings.ReadFromFile("test-fixtures/deployments.yaml")
+	content, err := ioutil.ReadFile("./test-fixtures/deployments.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	exampleSettings, err := settings.FromBytes(content)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/api/parameters.go
+++ b/pkg/api/parameters.go
@@ -7,6 +7,4 @@ type Parameters struct {
 	GitHubToken   string `mapstructure:"github-token"`
 	GELFAddress   string `mapstructure:"gelf-address"`
 	StatsdAddress string `mapstructure:"statsd-address"`
-
-	Filename string
 }

--- a/pkg/settings/settings.go
+++ b/pkg/settings/settings.go
@@ -1,9 +1,7 @@
 package settings
 
 import (
-	"io/ioutil"
 	"path"
-	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -14,12 +12,6 @@ import (
 
 	"github.com/rebuy-de/kubernetes-deployment/pkg/gh"
 )
-
-// This matches the value of `.metadata.selfLink` if ConfigMaps. It is a bit
-// weird for identifying that a ConfigMap is requested, but it is good enough
-// for now.
-var reKubeSelfLink = regexp.MustCompile(`^/api/v1/namespaces/([^/]+)/configmaps/([^/]+)$`)
-var configMapFilename = `settings.yaml`
 
 type Settings struct {
 	Defaults Service  `yaml:"defaults"`
@@ -36,58 +28,27 @@ func FromBytes(data []byte) (*Settings, error) {
 	return config, nil
 }
 
-func Read(location string, ghClient gh.Interface, kubeClient kubernetes.Interface) (*Settings, error) {
-	if strings.HasPrefix(location, "github.com") {
-		return ReadFromGitHub(location, ghClient)
-	} else if reKubeSelfLink.MatchString(location) {
-		matches := reKubeSelfLink.FindStringSubmatch(location)
-		return ReadFromConfigMap(matches[1], matches[2], kubeClient)
-	} else {
-		return ReadFromFile(location)
-	}
-}
+func Read(client kubernetes.Interface) (*Settings, error) {
+	const (
+		namespace = "default"
+		name      = "kubernetes-deployment"
+	)
 
-func ReadFromFile(filename string) (*Settings, error) {
-	data, err := ioutil.ReadFile(filename)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Could not open file '%s'", filename)
-	}
-
-	return FromBytes(data)
-
-}
-
-func ReadFromConfigMap(namespace, name string, client kubernetes.Interface) (*Settings, error) {
-	cm, err := client.Core().ConfigMaps(namespace).Get(name, meta.GetOptions{})
+	cm, err := client.Core().ConfigMaps("default").Get("kubernetes-deployment", meta.GetOptions{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "Could read ConfigMap '%s/%s'", namespace, name)
 	}
 
-	content, exists := cm.Data[configMapFilename]
+	if len(cm.Data) != 1 {
+		return nil, errors.Errorf("ConfigMap '%s/%s' needs to contain exactly one file", namespace, name)
+	}
 
-	if !exists {
-		return nil, errors.Errorf("Configmap '%s/%s' does not have a file named '%s'",
-			namespace, name, configMapFilename)
+	var content string
+	for _, data := range cm.Data {
+		content = data
 	}
 
 	return FromBytes([]byte(content))
-}
-
-func ReadFromGitHub(filename string, client gh.Interface) (*Settings, error) {
-	location, err := gh.NewLocation(filename)
-	if err != nil {
-		return nil, errors.Wrapf(err, "parse GitHub location '%s'; use './' prefix to use a directory named 'github.com'", filename)
-	}
-
-	location.Defaults(gh.Location{
-		Ref: "master",
-	})
-
-	file, err := client.GetFile(location)
-	if err != nil {
-		return nil, errors.Wrapf(err, "could not download file '%s'", location)
-	}
-	return FromBytes([]byte(file.Content))
 }
 
 func (s *Settings) Service(project string) *Service {

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -12,16 +12,9 @@ import (
 	"github.com/rebuy-de/rebuy-go-sdk/testutil"
 )
 
-func TestReadFile(t *testing.T) {
-	settings, err := Read("./test-fixtures/services.yaml", nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+func testCreateSettings(t *testing.T) *Settings {
+	t.Helper()
 
-	testutil.AssertGoldenYAML(t, "test-fixtures/services-plain-golden.yaml", settings)
-}
-
-func TestReadConfigMap(t *testing.T) {
 	original, err := ioutil.ReadFile("./test-fixtures/services.yaml")
 	if err != nil {
 		t.Fatal(err)
@@ -38,33 +31,28 @@ func TestReadConfigMap(t *testing.T) {
 	}
 
 	kube := fake.NewSimpleClientset(cm)
-	settings, err := Read("/api/v1/namespaces/default/configmaps/kubernetes-deployment", nil, kube)
+	settings, err := Read(kube)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// This uses the same golden file as TestReadFile, but this is fine since
-	// they actually should look the same.
+	return settings
+}
+
+func TestReadConfigMap(t *testing.T) {
+	settings := testCreateSettings(t)
 	testutil.AssertGoldenYAML(t, "test-fixtures/services-plain-golden.yaml", settings)
 }
 
 func TestClean(t *testing.T) {
-	settings, err := Read("./test-fixtures/services.yaml", nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	settings := testCreateSettings(t)
 	settings.Clean()
 
 	testutil.AssertGoldenYAML(t, "test-fixtures/services-clean-golden.yaml", settings)
 }
 
 func TestServiceGuessing(t *testing.T) {
-	settings, err := Read("./test-fixtures/services.yaml", nil, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	settings := testCreateSettings(t)
 	settings.Clean()
 
 	cases := []struct {


### PR DESCRIPTION
There is no need for reading settings from file anymore. Also it reduces the lines of code, which is nice.

Now it always reads the settings from the ConfigMap `default/kubernetes-deployment`.