### PR TITLE
CLOUD-1928 Replace colons in labels since they are forbidden

### DIFF
--- a/pkg/interceptors/annotater/interceptor.go
+++ b/pkg/interceptors/annotater/interceptor.go
@@ -2,6 +2,7 @@ package annotater
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/benbjohnson/clock"
@@ -106,7 +107,7 @@ func (i *Interceptor) annotate(workload string, obj v1meta.Object, isRoot bool) 
 		labels = map[string]string{}
 	}
 
-	labels[key("workload-name")] = workload
+	labels[key("workload-name")] = strings.Replace(workload, ":", "-", -1)
 	labels[key("repo")] = i.branch.Location.Repo
 	labels[key("branch")] = i.branch.Name
 


### PR DESCRIPTION
In case of the VPA the label `workload-name` contained a colon, which caused some trouble.

https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
