### PR TITLE
sort files from GitHub

### DIFF
--- a/pkg/gh/client.go
+++ b/pkg/gh/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -238,6 +239,8 @@ func (gh *API) GetFiles(location *Location) ([]File, error) {
 
 		files = append(files, file)
 	}
+
+	sort.Sort(FileByName(files))
 
 	return files, nil
 }

--- a/pkg/gh/file.go
+++ b/pkg/gh/file.go
@@ -11,3 +11,9 @@ func (f *File) Name() string {
 	_, name := path.Split(f.Location.Path)
 	return name
 }
+
+type FileByName []File
+
+func (a FileByName) Len() int           { return len(a) }
+func (a FileByName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a FileByName) Less(i, j int) bool { return a[i].Location.String() < a[j].Location.String() }


### PR DESCRIPTION
Linkerd is still making trouble on some staging deployments, because the namespace is missing. This should fix it.